### PR TITLE
Add Support to Set Up pnpm on macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,11 @@ on:
 jobs:
   test-action:
     name: Test Action
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-13]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4.2.2

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -69,6 +69,8 @@ function getPlatform() {
     switch (os.platform()) {
         case "linux":
             return "linux";
+        case "darwin":
+            return "macos";
         default:
             throw new Error(`Unknown platform: ${os.platform()}`);
     }

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -65,6 +65,15 @@ function logError(err) {
     process.stdout.write(`::error::${message}${os.EOL}`);
 }
 
+function getPlatform() {
+    switch (os.platform()) {
+        case "linux":
+            return "linux";
+        default:
+            throw new Error(`Unknown platform: ${os.platform()}`);
+    }
+}
+
 async function downloadFile(url, dest) {
     return new Promise((resolve, reject) => {
         https
@@ -100,9 +109,9 @@ async function createPnpmHome() {
     await fsPromises.mkdir(pnpmHome);
     return pnpmHome;
 }
-async function downloadPnpm(pnpmHome) {
+async function downloadPnpm(pnpmHome, platform) {
     const pnpmFile = path.join(pnpmHome, "pnpm");
-    await downloadFile("https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64", pnpmFile);
+    await downloadFile(`https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-x64`, pnpmFile);
     await fsPromises.chmod(pnpmFile, "755");
 }
 async function setupPnpm(pnpmHome) {
@@ -110,9 +119,10 @@ async function setupPnpm(pnpmHome) {
 }
 
 try {
+    const platform = getPlatform();
     const pnpmHome = await createPnpmHome();
     logInfo(`Downloading pnpm to ${pnpmHome}...`);
-    await downloadPnpm(pnpmHome);
+    await downloadPnpm(pnpmHome, platform);
     await setupPnpm(pnpmHome);
 }
 catch (err) {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -7,6 +7,10 @@ vi.mock("gha-utils", () => ({
   logInfo: vi.fn(),
 }));
 
+vi.mock("./platform.js", () => ({
+  getPlatform: vi.fn().mockReturnValue("linux"),
+}));
+
 vi.mock("./pnpm.js", () => ({
   createPnpmHome: vi.fn().mockResolvedValue("/pnpm"),
   downloadPnpm: vi.fn().mockResolvedValue(undefined),
@@ -20,9 +24,12 @@ beforeEach(() => {
 it("should download pnpm", async () => {
   await import("./main.js");
 
+  expect(logError).not.toBeCalled();
+  expect(process.exitCode).toBeUndefined();
+
   expect(createPnpmHome).toBeCalled();
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
-  expect(downloadPnpm).toBeCalledWith("/pnpm");
+  expect(downloadPnpm).toBeCalledWith("/pnpm", "linux");
   expect(setupPnpm).toBeCalledWith("/pnpm");
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import { logError, logInfo } from "gha-utils";
+import { getPlatform } from "./platform.js";
 import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 try {
+  const platform = getPlatform();
   const pnpmHome = await createPnpmHome();
 
   logInfo(`Downloading pnpm to ${pnpmHome}...`);
-  await downloadPnpm(pnpmHome);
+  await downloadPnpm(pnpmHome, platform);
   await setupPnpm(pnpmHome);
 } catch (err) {
   logError(err);

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -1,0 +1,17 @@
+import os from "node:os";
+import { describe, it, expect, vi } from "vitest";
+import { getPlatform } from "./platform.js";
+
+vi.mock("node:os", () => ({ default: { platform: vi.fn() } }));
+
+describe("retrieve the platform", () => {
+  it("should retrieve the platform", () => {
+    vi.mocked(os.platform).mockReturnValue("linux");
+    expect(getPlatform()).toBe("linux");
+  });
+
+  it("should fail to retrieve the platform", () => {
+    vi.mocked(os.platform).mockReturnValue("android");
+    expect(() => getPlatform()).toThrow("Unknown platform: android");
+  });
+});

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -5,9 +5,14 @@ import { getPlatform } from "./platform.js";
 vi.mock("node:os", () => ({ default: { platform: vi.fn() } }));
 
 describe("retrieve the platform", () => {
-  it("should retrieve the platform", () => {
+  it("should retrieve the platform on Linux", () => {
     vi.mocked(os.platform).mockReturnValue("linux");
     expect(getPlatform()).toBe("linux");
+  });
+
+  it("should retrieve the platform on macOS", () => {
+    vi.mocked(os.platform).mockReturnValue("darwin");
+    expect(getPlatform()).toBe("macos");
   });
 
   it("should fail to retrieve the platform", () => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,12 @@
+import os from "node:os";
+
+export type Platform = "linux";
+
+export function getPlatform(): Platform {
+  switch (os.platform()) {
+    case "linux":
+      return "linux";
+    default:
+      throw new Error(`Unknown platform: ${os.platform()}`);
+  }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,11 +1,13 @@
 import os from "node:os";
 
-export type Platform = "linux";
+export type Platform = "linux" | "macos";
 
 export function getPlatform(): Platform {
   switch (os.platform()) {
     case "linux":
       return "linux";
+    case "darwin":
+      return "macos";
     default:
       throw new Error(`Unknown platform: ${os.platform()}`);
   }

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -30,7 +30,7 @@ it("should create a pnpm home directory", async () => {
 });
 
 it("should download pnpm", async () => {
-  await downloadPnpm("/pnpm");
+  await downloadPnpm("/pnpm", "linux");
 
   expect(downloadFile).toBeCalledWith(
     "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -2,6 +2,7 @@ import { addPath, setEnv } from "gha-utils";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { downloadFile } from "./download.js";
+import type { Platform } from "./platform.js";
 
 export async function createPnpmHome(): Promise<string> {
   const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm");
@@ -9,10 +10,13 @@ export async function createPnpmHome(): Promise<string> {
   return pnpmHome;
 }
 
-export async function downloadPnpm(pnpmHome: string): Promise<void> {
+export async function downloadPnpm(
+  pnpmHome: string,
+  platform: Platform,
+): Promise<void> {
   const pnpmFile = path.join(pnpmHome, "pnpm");
   await downloadFile(
-    "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",
+    `https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-x64`,
     pnpmFile,
   );
   await fsPromises.chmod(pnpmFile, "755");


### PR DESCRIPTION
This pull request resolves #10 by adding support for setting up pnpm on x64 macOS. In doing so, it introduces a new `getPlatform` function to determine the correct platform for downloading the pnpm prebuilt binary.  