### PR TITLE
Abstract and Organize pnpm Functions

### DIFF
--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -105,12 +105,15 @@ async function downloadPnpm(pnpmHome) {
     await downloadFile("https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64", pnpmFile);
     await fsPromises.chmod(pnpmFile, "755");
 }
+async function setupPnpm(pnpmHome) {
+    await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
+}
 
 try {
     const pnpmHome = await createPnpmHome();
     logInfo(`Downloading pnpm to ${pnpmHome}...`);
     await downloadPnpm(pnpmHome);
-    await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
+    await setupPnpm(pnpmHome);
 }
 catch (err) {
     logError(err);

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -95,11 +95,16 @@ async function downloadFile(url, dest) {
     });
 }
 
-try {
+async function createPnpmHome() {
     const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE, "pnpm");
+    await fsPromises.mkdir(pnpmHome);
+    return pnpmHome;
+}
+
+try {
+    const pnpmHome = await createPnpmHome();
     const pnpmFile = path.join(pnpmHome, "pnpm");
     logInfo(`Downloading pnpm to ${pnpmFile}...`);
-    await fsPromises.mkdir(pnpmHome);
     await downloadFile("https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64", pnpmFile);
     await fsPromises.chmod(pnpmFile, "755");
     await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -100,13 +100,16 @@ async function createPnpmHome() {
     await fsPromises.mkdir(pnpmHome);
     return pnpmHome;
 }
+async function downloadPnpm(pnpmHome) {
+    const pnpmFile = path.join(pnpmHome, "pnpm");
+    await downloadFile("https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64", pnpmFile);
+    await fsPromises.chmod(pnpmFile, "755");
+}
 
 try {
     const pnpmHome = await createPnpmHome();
-    const pnpmFile = path.join(pnpmHome, "pnpm");
-    logInfo(`Downloading pnpm to ${pnpmFile}...`);
-    await downloadFile("https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64", pnpmFile);
-    await fsPromises.chmod(pnpmFile, "755");
+    logInfo(`Downloading pnpm to ${pnpmHome}...`);
+    await downloadPnpm(pnpmHome);
     await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
 }
 catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,13 @@ import { addPath, logError, logInfo, setEnv } from "gha-utils";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { downloadFile } from "./download.js";
+import { createPnpmHome } from "./pnpm.js";
 
 try {
-  const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm");
+  const pnpmHome = await createPnpmHome();
   const pnpmFile = path.join(pnpmHome, "pnpm");
 
   logInfo(`Downloading pnpm to ${pnpmFile}...`);
-  await fsPromises.mkdir(pnpmHome);
   await downloadFile(
     "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",
     pnpmFile,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,12 @@
-import { addPath, logError, logInfo, setEnv } from "gha-utils";
-import { createPnpmHome, downloadPnpm } from "./pnpm.js";
+import { logError, logInfo } from "gha-utils";
+import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 try {
   const pnpmHome = await createPnpmHome();
 
   logInfo(`Downloading pnpm to ${pnpmHome}...`);
   await downloadPnpm(pnpmHome);
-
-  await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
+  await setupPnpm(pnpmHome);
 } catch (err) {
   logError(err);
   process.exitCode = 1;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,11 @@
 import { addPath, logError, logInfo, setEnv } from "gha-utils";
-import fsPromises from "node:fs/promises";
-import path from "node:path";
-import { downloadFile } from "./download.js";
-import { createPnpmHome } from "./pnpm.js";
+import { createPnpmHome, downloadPnpm } from "./pnpm.js";
 
 try {
   const pnpmHome = await createPnpmHome();
-  const pnpmFile = path.join(pnpmHome, "pnpm");
 
-  logInfo(`Downloading pnpm to ${pnpmFile}...`);
-  await downloadFile(
-    "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",
-    pnpmFile,
-  );
-  await fsPromises.chmod(pnpmFile, "755");
+  logInfo(`Downloading pnpm to ${pnpmHome}...`);
+  await downloadPnpm(pnpmHome);
 
   await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
 } catch (err) {

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,7 +1,13 @@
+import { addPath, setEnv } from "gha-utils";
 import fsPromises from "node:fs/promises";
 import { expect, it, vi } from "vitest";
-import { createPnpmHome, downloadPnpm } from "./pnpm";
+import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm";
 import { downloadFile } from "./download";
+
+vi.mock("gha-utils", () => ({
+  addPath: vi.fn().mockResolvedValue(undefined),
+  setEnv: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("node:fs/promises", () => ({
   default: {
@@ -31,4 +37,11 @@ it("should download pnpm", async () => {
     "/pnpm/pnpm",
   );
   expect(fsPromises.chmod).toBeCalledWith("/pnpm/pnpm", "755");
+});
+
+it("should setup pnpm", async () => {
+  await setupPnpm("/pnpm");
+
+  expect(addPath).toBeCalledWith("/pnpm");
+  expect(setEnv).toBeCalledWith("PNPM_HOME", "/pnpm");
 });

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,11 +1,17 @@
 import fsPromises from "node:fs/promises";
 import { expect, it, vi } from "vitest";
-import { createPnpmHome } from "./pnpm";
+import { createPnpmHome, downloadPnpm } from "./pnpm";
+import { downloadFile } from "./download";
 
 vi.mock("node:fs/promises", () => ({
   default: {
+    chmod: vi.fn().mockResolvedValue(undefined),
     mkdir: vi.fn().mockResolvedValue(undefined),
   },
+}));
+
+vi.mock("./download.js", () => ({
+  downloadFile: vi.fn().mockResolvedValue(undefined),
 }));
 
 it("should create a pnpm home directory", async () => {
@@ -15,4 +21,14 @@ it("should create a pnpm home directory", async () => {
 
   expect(pnpmHome).toBe("/tool/pnpm");
   expect(fsPromises.mkdir).toBeCalledWith(pnpmHome);
+});
+
+it("should download pnpm", async () => {
+  await downloadPnpm("/pnpm");
+
+  expect(downloadFile).toBeCalledWith(
+    "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",
+    "/pnpm/pnpm",
+  );
+  expect(fsPromises.chmod).toBeCalledWith("/pnpm/pnpm", "755");
 });

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,0 +1,18 @@
+import fsPromises from "node:fs/promises";
+import { expect, it, vi } from "vitest";
+import { createPnpmHome } from "./pnpm";
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+it("should create a pnpm home directory", async () => {
+  process.env.RUNNER_TOOL_CACHE = "/tool";
+
+  const pnpmHome = await createPnpmHome();
+
+  expect(pnpmHome).toBe("/tool/pnpm");
+  expect(fsPromises.mkdir).toBeCalledWith(pnpmHome);
+});

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -1,8 +1,18 @@
 import fsPromises from "node:fs/promises";
 import path from "node:path";
+import { downloadFile } from "./download.js";
 
 export async function createPnpmHome(): Promise<string> {
   const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm");
   await fsPromises.mkdir(pnpmHome);
   return pnpmHome;
+}
+
+export async function downloadPnpm(pnpmHome: string): Promise<void> {
+  const pnpmFile = path.join(pnpmHome, "pnpm");
+  await downloadFile(
+    "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",
+    pnpmFile,
+  );
+  await fsPromises.chmod(pnpmFile, "755");
 }

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -1,0 +1,8 @@
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+
+export async function createPnpmHome(): Promise<string> {
+  const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm");
+  await fsPromises.mkdir(pnpmHome);
+  return pnpmHome;
+}

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -1,3 +1,4 @@
+import { addPath, setEnv } from "gha-utils";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { downloadFile } from "./download.js";
@@ -15,4 +16,8 @@ export async function downloadPnpm(pnpmHome: string): Promise<void> {
     pnpmFile,
   );
   await fsPromises.chmod(pnpmFile, "755");
+}
+
+export async function setupPnpm(pnpmHome: string): Promise<void> {
+  await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
 }


### PR DESCRIPTION
This pull request resolves #14 by abstracting and organizing pnpm-related functions into the `pnpm.ts` file. Additionally, it simplifies tests and enforces module mocking, particularly in the `main.test.ts` file.  
