### PR TITLE
Download pnpm Using Curl

### DIFF
--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -38,7 +38,7 @@ it("should fail to download a file", async () => {
       "https://raw.githubusercontent.com/pnpm/pnpm/refs/heads/main/LICENSEe",
       path.join(tempDir, "LICENSEe"),
     ),
-  ).rejects.toThrow("Not Found");
+  ).rejects.toThrow("curl: (22) The requested URL returned error: 404");
 });
 
 afterAll(async () => {


### PR DESCRIPTION
This pull request resolves #16 by modifying the `downloadFile` function to use `curl`, effectively updating the action to download pnpm using `curl` instead of Node's HTTP module.