### PR TITLE
Add Support for Downloading pnpm on ARM

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4.2.2

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -75,6 +75,14 @@ function getPlatform() {
             throw new Error(`Unknown platform: ${os.platform()}`);
     }
 }
+function getArchitecture() {
+    switch (os.arch()) {
+        case "x64":
+            return "x64";
+        default:
+            throw new Error(`Unknown architecture: ${os.arch()}`);
+    }
+}
 
 async function downloadFile(url, dest) {
     return new Promise((resolve, reject) => {
@@ -98,9 +106,9 @@ async function createPnpmHome() {
     await fsPromises.mkdir(pnpmHome);
     return pnpmHome;
 }
-async function downloadPnpm(pnpmHome, platform) {
+async function downloadPnpm(pnpmHome, platform, architecture) {
     const pnpmFile = path.join(pnpmHome, "pnpm");
-    await downloadFile(`https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-x64`, pnpmFile);
+    await downloadFile(`https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-${architecture}`, pnpmFile);
     await fsPromises.chmod(pnpmFile, "755");
 }
 async function setupPnpm(pnpmHome) {
@@ -109,9 +117,10 @@ async function setupPnpm(pnpmHome) {
 
 try {
     const platform = getPlatform();
+    const architecture = getArchitecture();
     const pnpmHome = await createPnpmHome();
     logInfo(`Downloading pnpm to ${pnpmHome}...`);
-    await downloadPnpm(pnpmHome, platform);
+    await downloadPnpm(pnpmHome, platform, architecture);
     await setupPnpm(pnpmHome);
 }
 catch (err) {

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -79,6 +79,8 @@ function getArchitecture() {
     switch (os.arch()) {
         case "x64":
             return "x64";
+        case "arm64":
+            return "arm64";
         default:
             throw new Error(`Unknown architecture: ${os.arch()}`);
     }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -8,6 +8,7 @@ vi.mock("gha-utils", () => ({
 }));
 
 vi.mock("./platform.js", () => ({
+  getArchitecture: vi.fn().mockReturnValue("x64"),
   getPlatform: vi.fn().mockReturnValue("linux"),
 }));
 
@@ -29,7 +30,7 @@ it("should download pnpm", async () => {
 
   expect(createPnpmHome).toBeCalled();
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
-  expect(downloadPnpm).toBeCalledWith("/pnpm", "linux");
+  expect(downloadPnpm).toBeCalledWith("/pnpm", "linux", "x64");
   expect(setupPnpm).toBeCalledWith("/pnpm");
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,14 @@
 import { logError, logInfo } from "gha-utils";
-import { getPlatform } from "./platform.js";
+import { getArchitecture, getPlatform } from "./platform.js";
 import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 try {
   const platform = getPlatform();
+  const architecture = getArchitecture();
   const pnpmHome = await createPnpmHome();
 
   logInfo(`Downloading pnpm to ${pnpmHome}...`);
-  await downloadPnpm(pnpmHome, platform);
+  await downloadPnpm(pnpmHome, platform, architecture);
   await setupPnpm(pnpmHome);
 } catch (err) {
   logError(err);

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -32,6 +32,11 @@ describe("retrieve the architecture", () => {
     expect(getArchitecture()).toBe("x64");
   });
 
+  it("should retrieve the architecture on arm64", () => {
+    vi.mocked(os.arch).mockReturnValue("arm64");
+    expect(getArchitecture()).toBe("arm64");
+  });
+
   it("should fail to retrieve the architecture", () => {
     vi.mocked(os.arch).mockReturnValue("ia32");
     expect(() => getArchitecture()).toThrow("Unknown architecture: ia32");

--- a/src/platform.test.ts
+++ b/src/platform.test.ts
@@ -1,8 +1,13 @@
 import os from "node:os";
 import { describe, it, expect, vi } from "vitest";
-import { getPlatform } from "./platform.js";
+import { getArchitecture, getPlatform } from "./platform.js";
 
-vi.mock("node:os", () => ({ default: { platform: vi.fn() } }));
+vi.mock("node:os", () => ({
+  default: {
+    arch: vi.fn(),
+    platform: vi.fn(),
+  },
+}));
 
 describe("retrieve the platform", () => {
   it("should retrieve the platform on Linux", () => {
@@ -18,5 +23,17 @@ describe("retrieve the platform", () => {
   it("should fail to retrieve the platform", () => {
     vi.mocked(os.platform).mockReturnValue("android");
     expect(() => getPlatform()).toThrow("Unknown platform: android");
+  });
+});
+
+describe("retrieve the architecture", () => {
+  it("should retrieve the architecture on x64", () => {
+    vi.mocked(os.arch).mockReturnValue("x64");
+    expect(getArchitecture()).toBe("x64");
+  });
+
+  it("should fail to retrieve the architecture", () => {
+    vi.mocked(os.arch).mockReturnValue("ia32");
+    expect(() => getArchitecture()).toThrow("Unknown architecture: ia32");
   });
 });

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 
 export type Platform = "linux" | "macos";
+export type Architecture = "x64";
 
 export function getPlatform(): Platform {
   switch (os.platform()) {
@@ -10,5 +11,14 @@ export function getPlatform(): Platform {
       return "macos";
     default:
       throw new Error(`Unknown platform: ${os.platform()}`);
+  }
+}
+
+export function getArchitecture(): Architecture {
+  switch (os.arch()) {
+    case "x64":
+      return "x64";
+    default:
+      throw new Error(`Unknown architecture: ${os.arch()}`);
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 
 export type Platform = "linux" | "macos";
-export type Architecture = "x64";
+export type Architecture = "x64" | "arm64";
 
 export function getPlatform(): Platform {
   switch (os.platform()) {
@@ -18,6 +18,8 @@ export function getArchitecture(): Architecture {
   switch (os.arch()) {
     case "x64":
       return "x64";
+    case "arm64":
+      return "arm64";
     default:
       throw new Error(`Unknown architecture: ${os.arch()}`);
   }

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -30,7 +30,7 @@ it("should create a pnpm home directory", async () => {
 });
 
 it("should download pnpm", async () => {
-  await downloadPnpm("/pnpm", "linux");
+  await downloadPnpm("/pnpm", "linux", "x64");
 
   expect(downloadFile).toBeCalledWith(
     "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -2,7 +2,7 @@ import { addPath, setEnv } from "gha-utils";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { downloadFile } from "./download.js";
-import type { Platform } from "./platform.js";
+import type { Architecture, Platform } from "./platform.js";
 
 export async function createPnpmHome(): Promise<string> {
   const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm");
@@ -13,10 +13,11 @@ export async function createPnpmHome(): Promise<string> {
 export async function downloadPnpm(
   pnpmHome: string,
   platform: Platform,
+  architecture: Architecture,
 ): Promise<void> {
   const pnpmFile = path.join(pnpmHome, "pnpm");
   await downloadFile(
-    `https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-x64`,
+    `https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-${architecture}`,
     pnpmFile,
   );
   await fsPromises.chmod(pnpmFile, "755");


### PR DESCRIPTION
This pull request resolves #18 by adding support for setting up pnpm on runners with ARM architecture. In doing so, it modifies the `downloadPnpm` function to require an architecture parameter and introduces a new `getArchitecture` function to ensure that the current architecture is supported for pnpm setup.