### PR TITLE
Add Support for Specifying pnpm Version During Setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,3 +27,11 @@ jobs:
 
       - name: Check pnpm
         run: pnpm --version
+
+      - name: Setup pnpm With a Specified Version
+        uses: ./setup-pnpm-action
+        with:
+          version: 9.15.5
+
+      - name: Check pnpm
+        run: pnpm --version

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ description: Set up pnpm with a specified version
 branding:
   icon: chevrons-right
   color: black
+inputs:
+  version:
+    description: The pnpm version to set up
 runs:
   using: node20
   main: dist/main.bundle.mjs

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -20,6 +20,16 @@ function mustGetEnvironment(name) {
     return value;
 }
 /**
+ * Retrieves the value of a GitHub Actions input.
+ *
+ * @param name - The name of the GitHub Actions input.
+ * @returns The value of the GitHub Actions input, or an empty string if not found.
+ */
+function getInput(name) {
+    const value = process.env[`INPUT_${name.toUpperCase()}`] ?? "";
+    return value.trim();
+}
+/**
  * Sets the value of an environment variable in GitHub Actions.
  *
  * @param name - The name of the environment variable.
@@ -118,11 +128,14 @@ async function setupPnpm(pnpmHome) {
 }
 
 try {
+    let version = getInput("version");
+    if (version === "")
+        version = "10.2.1";
     const platform = getPlatform();
     const architecture = getArchitecture();
     const pnpmHome = await createPnpmHome();
     logInfo(`Downloading pnpm to ${pnpmHome}...`);
-    await downloadPnpm(pnpmHome, "10.2.1", platform, architecture);
+    await downloadPnpm(pnpmHome, version, platform, architecture);
     await setupPnpm(pnpmHome);
 }
 catch (err) {

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -108,9 +108,9 @@ async function createPnpmHome() {
     await fsPromises.mkdir(pnpmHome);
     return pnpmHome;
 }
-async function downloadPnpm(pnpmHome, platform, architecture) {
+async function downloadPnpm(pnpmHome, version, platform, architecture) {
     const pnpmFile = path.join(pnpmHome, "pnpm");
-    await downloadFile(`https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-${architecture}`, pnpmFile);
+    await downloadFile(`https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${platform}-${architecture}`, pnpmFile);
     await fsPromises.chmod(pnpmFile, "755");
 }
 async function setupPnpm(pnpmHome) {
@@ -122,7 +122,7 @@ try {
     const architecture = getArchitecture();
     const pnpmHome = await createPnpmHome();
     logInfo(`Downloading pnpm to ${pnpmHome}...`);
-    await downloadPnpm(pnpmHome, platform, architecture);
+    await downloadPnpm(pnpmHome, "10.2.1", platform, architecture);
     await setupPnpm(pnpmHome);
 }
 catch (err) {

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -113,9 +113,9 @@ async function downloadFile(url, dest) {
     });
 }
 
-async function createPnpmHome() {
-    const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE, "pnpm");
-    await fsPromises.mkdir(pnpmHome);
+async function createPnpmHome(version) {
+    const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE, "pnpm", version);
+    await fsPromises.mkdir(pnpmHome, { recursive: true });
     return pnpmHome;
 }
 async function downloadPnpm(pnpmHome, version, platform, architecture) {
@@ -133,7 +133,7 @@ try {
         version = "10.2.1";
     const platform = getPlatform();
     const architecture = getArchitecture();
-    const pnpmHome = await createPnpmHome();
+    const pnpmHome = await createPnpmHome(version);
     logInfo(`Downloading pnpm to ${pnpmHome}...`);
     await downloadPnpm(pnpmHome, version, platform, architecture);
     await setupPnpm(pnpmHome);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -29,7 +29,7 @@ it("should download pnpm", async () => {
   expect(logError).not.toBeCalled();
   expect(process.exitCode).toBeUndefined();
 
-  expect(createPnpmHome).toBeCalled();
+  expect(createPnpmHome).toBeCalledWith("10.2.1");
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
   expect(downloadPnpm).toBeCalledWith("/pnpm", "10.2.1", "linux", "x64");
   expect(setupPnpm).toBeCalledWith("/pnpm");
@@ -43,7 +43,7 @@ it("should download pnpm with a specified version", async () => {
   expect(logError).not.toBeCalled();
   expect(process.exitCode).toBeUndefined();
 
-  expect(createPnpmHome).toBeCalled();
+  expect(createPnpmHome).toBeCalledWith("9.15.5");
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
   expect(downloadPnpm).toBeCalledWith("/pnpm", "9.15.5", "linux", "x64");
   expect(setupPnpm).toBeCalledWith("/pnpm");

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -30,7 +30,7 @@ it("should download pnpm", async () => {
 
   expect(createPnpmHome).toBeCalled();
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
-  expect(downloadPnpm).toBeCalledWith("/pnpm", "linux", "x64");
+  expect(downloadPnpm).toBeCalledWith("/pnpm", "10.2.1", "linux", "x64");
   expect(setupPnpm).toBeCalledWith("/pnpm");
 });
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,8 +1,9 @@
-import { logError, logInfo } from "gha-utils";
+import { getInput, logError, logInfo } from "gha-utils";
 import { beforeEach, expect, it, vi } from "vitest";
 import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 vi.mock("gha-utils", () => ({
+  getInput: vi.fn().mockReturnValue(""),
   logError: vi.fn(),
   logInfo: vi.fn(),
 }));
@@ -31,6 +32,20 @@ it("should download pnpm", async () => {
   expect(createPnpmHome).toBeCalled();
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
   expect(downloadPnpm).toBeCalledWith("/pnpm", "10.2.1", "linux", "x64");
+  expect(setupPnpm).toBeCalledWith("/pnpm");
+});
+
+it("should download pnpm with a specified version", async () => {
+  vi.mocked(getInput).mockReturnValue("9.15.5");
+
+  await import("./main.js");
+
+  expect(logError).not.toBeCalled();
+  expect(process.exitCode).toBeUndefined();
+
+  expect(createPnpmHome).toBeCalled();
+  expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
+  expect(downloadPnpm).toBeCalledWith("/pnpm", "9.15.5", "linux", "x64");
   expect(setupPnpm).toBeCalledWith("/pnpm");
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ try {
   const pnpmHome = await createPnpmHome();
 
   logInfo(`Downloading pnpm to ${pnpmHome}...`);
-  await downloadPnpm(pnpmHome, platform, architecture);
+  await downloadPnpm(pnpmHome, "10.2.1", platform, architecture);
   await setupPnpm(pnpmHome);
 } catch (err) {
   logError(err);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ try {
 
   const platform = getPlatform();
   const architecture = getArchitecture();
-  const pnpmHome = await createPnpmHome();
+  const pnpmHome = await createPnpmHome(version);
 
   logInfo(`Downloading pnpm to ${pnpmHome}...`);
   await downloadPnpm(pnpmHome, version, platform, architecture);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,17 @@
-import { logError, logInfo } from "gha-utils";
+import { getInput, logError, logInfo } from "gha-utils";
 import { getArchitecture, getPlatform } from "./platform.js";
 import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 try {
+  let version = getInput("version");
+  if (version === "") version = "10.2.1";
+
   const platform = getPlatform();
   const architecture = getArchitecture();
   const pnpmHome = await createPnpmHome();
 
   logInfo(`Downloading pnpm to ${pnpmHome}...`);
-  await downloadPnpm(pnpmHome, "10.2.1", platform, architecture);
+  await downloadPnpm(pnpmHome, version, platform, architecture);
   await setupPnpm(pnpmHome);
 } catch (err) {
   logError(err);

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -23,10 +23,10 @@ vi.mock("./download.js", () => ({
 it("should create a pnpm home directory", async () => {
   process.env.RUNNER_TOOL_CACHE = "/tool";
 
-  const pnpmHome = await createPnpmHome();
+  const pnpmHome = await createPnpmHome("10.2.1");
 
-  expect(pnpmHome).toBe("/tool/pnpm");
-  expect(fsPromises.mkdir).toBeCalledWith(pnpmHome);
+  expect(pnpmHome).toBe("/tool/pnpm/10.2.1");
+  expect(fsPromises.mkdir).toBeCalledWith(pnpmHome, { recursive: true });
 });
 
 it("should download pnpm", async () => {

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -30,7 +30,7 @@ it("should create a pnpm home directory", async () => {
 });
 
 it("should download pnpm", async () => {
-  await downloadPnpm("/pnpm", "linux", "x64");
+  await downloadPnpm("/pnpm", "10.2.1", "linux", "x64");
 
   expect(downloadFile).toBeCalledWith(
     "https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-linux-x64",

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -12,12 +12,13 @@ export async function createPnpmHome(): Promise<string> {
 
 export async function downloadPnpm(
   pnpmHome: string,
+  version: string,
   platform: Platform,
   architecture: Architecture,
 ): Promise<void> {
   const pnpmFile = path.join(pnpmHome, "pnpm");
   await downloadFile(
-    `https://github.com/pnpm/pnpm/releases/download/v10.2.1/pnpm-${platform}-${architecture}`,
+    `https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${platform}-${architecture}`,
     pnpmFile,
   );
   await fsPromises.chmod(pnpmFile, "755");

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -4,9 +4,9 @@ import path from "node:path";
 import { downloadFile } from "./download.js";
 import type { Architecture, Platform } from "./platform.js";
 
-export async function createPnpmHome(): Promise<string> {
-  const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm");
-  await fsPromises.mkdir(pnpmHome);
+export async function createPnpmHome(version: string): Promise<string> {
+  const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm", version);
+  await fsPromises.mkdir(pnpmHome, { recursive: true });
   return pnpmHome;
 }
 


### PR DESCRIPTION
This pull request resolves #20 by adding support for specifying the pnpm version in this action. It introduces a new `version` input and modifies the `createPnpmHome` and `downloadPnpm` functions to require the version parameter.