### PR TITLE
Add Support for Specifying pnpm Version Using a Tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   version:
     description: The pnpm version to set up
-    default: 10.2.1
+    default: latest
 runs:
   using: node20
   main: dist/main.bundle.mjs

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -16,6 +16,7 @@ vi.mock("./platform.js", () => ({
 vi.mock("./pnpm.js", () => ({
   createPnpmHome: vi.fn().mockResolvedValue("/pnpm"),
   downloadPnpm: vi.fn().mockResolvedValue(undefined),
+  resolvePnpmVersion: vi.fn().mockImplementation(async (version) => version),
   setupPnpm: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,15 @@
 import { getInput, logError, logInfo } from "gha-utils";
 import { getArchitecture, getPlatform } from "./platform.js";
-import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
+
+import {
+  createPnpmHome,
+  downloadPnpm,
+  resolvePnpmVersion,
+  setupPnpm,
+} from "./pnpm.js";
 
 try {
-  const version = getInput("version");
+  const version = await resolvePnpmVersion(getInput("version"));
   const platform = getPlatform();
   const architecture = getArchitecture();
   const pnpmHome = await createPnpmHome(version);

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,7 +1,14 @@
 import { addPath, setEnv } from "gha-utils";
 import fsPromises from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
-import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm";
+
+import {
+  createPnpmHome,
+  downloadPnpm,
+  resolvePnpmVersion,
+  setupPnpm,
+} from "./pnpm";
+
 import { downloadFile } from "./download";
 
 vi.mock("gha-utils", () => ({
@@ -27,6 +34,22 @@ it("should create a pnpm home directory", async () => {
 
   expect(pnpmHome).toBe("/tool/pnpm/10.2.1");
   expect(fsPromises.mkdir).toBeCalledWith(pnpmHome, { recursive: true });
+});
+
+describe("resolve pnpm version", () => {
+  it("should resolve pnpm version", async () => {
+    await expect(resolvePnpmVersion("10.2.1")).resolves.toBe("10.2.1");
+  });
+
+  it("should resolve pnpm version using tag", async () => {
+    await expect(resolvePnpmVersion("latest")).resolves.not.toThrow();
+  });
+
+  it("should not resolve pnpm version", async () => {
+    await expect(resolvePnpmVersion("invalid")).rejects.toThrow(
+      "Unknown version: invalid",
+    );
+  });
 });
 
 describe("download pnpm", () => {

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -10,6 +10,20 @@ export async function createPnpmHome(version: string): Promise<string> {
   return pnpmHome;
 }
 
+export async function resolvePnpmVersion(version: string): Promise<string> {
+  const res = await fetch("https://registry.npmjs.org/@pnpm/exe");
+  if (res.ok) {
+    const data = await res.json();
+    if ("dist-tags" in data && version in data["dist-tags"]) {
+      return data["dist-tags"][version];
+    }
+    if ("versions" in data && version in data["versions"]) {
+      return version;
+    }
+  }
+  throw new Error(`Unknown version: ${version}`);
+}
+
 export async function downloadPnpm(
   pnpmHome: string,
   version: string,


### PR DESCRIPTION
This pull request resolves #24 by adding support for specifying the pnpm version using a tag. To achieve this, it introduces a new `resolvePnpmVersion` function to resolve the given version or tag to the actual version number. Additionally, this function will also validate whether the specified version is available.  