### PR TITLE
Specify Default Version for Setup in Action Schema

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ branding:
 inputs:
   version:
     description: The pnpm version to set up
+    default: 10.2.1
 runs:
   using: node20
   main: dist/main.bundle.mjs

--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -131,9 +131,7 @@ async function setupPnpm(pnpmHome) {
 }
 
 try {
-    let version = getInput("version");
-    if (version === "")
-        version = "10.2.1";
+    const version = getInput("version");
     const platform = getPlatform();
     const architecture = getArchitecture();
     const pnpmHome = await createPnpmHome(version);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,9 +1,9 @@
-import { getInput, logError, logInfo } from "gha-utils";
+import { logError, logInfo } from "gha-utils";
 import { beforeEach, expect, it, vi } from "vitest";
 import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 vi.mock("gha-utils", () => ({
-  getInput: vi.fn().mockReturnValue(""),
+  getInput: vi.fn().mockReturnValue("10.2.1"),
   logError: vi.fn(),
   logInfo: vi.fn(),
 }));
@@ -32,20 +32,6 @@ it("should download pnpm", async () => {
   expect(createPnpmHome).toBeCalledWith("10.2.1");
   expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
   expect(downloadPnpm).toBeCalledWith("/pnpm", "10.2.1", "linux", "x64");
-  expect(setupPnpm).toBeCalledWith("/pnpm");
-});
-
-it("should download pnpm with a specified version", async () => {
-  vi.mocked(getInput).mockReturnValue("9.15.5");
-
-  await import("./main.js");
-
-  expect(logError).not.toBeCalled();
-  expect(process.exitCode).toBeUndefined();
-
-  expect(createPnpmHome).toBeCalledWith("9.15.5");
-  expect(logInfo).toBeCalledWith("Downloading pnpm to /pnpm...");
-  expect(downloadPnpm).toBeCalledWith("/pnpm", "9.15.5", "linux", "x64");
   expect(setupPnpm).toBeCalledWith("/pnpm");
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,7 @@ import { getArchitecture, getPlatform } from "./platform.js";
 import { createPnpmHome, downloadPnpm, setupPnpm } from "./pnpm.js";
 
 try {
-  let version = getInput("version");
-  if (version === "") version = "10.2.1";
-
+  const version = getInput("version");
   const platform = getPlatform();
   const architecture = getArchitecture();
   const pnpmHome = await createPnpmHome(version);


### PR DESCRIPTION
This pull request resolves #26 by specifying the default pnpm version in the `action.yml` file instead of the `src/main.ts` file. This change also simplifies the `src/main.test.ts` file.