### PR TITLE
Bump Node to version 23.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "lefthook"
     ],
     "executionEnv": {
-      "nodeVersion": "23.8.0"
+      "nodeVersion": "23.9.0"
     }
   }
 }


### PR DESCRIPTION
This pull request bumps the Node.js version specified in the `package.json` file to version [23.9.0](https://github.com/nodejs/node/releases/tag/v23.9.0).