### PR TITLE
Specify Node.js Version Using `.npmrc` File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.git*
+!.npmrc
 !.prettierignore
 
 node_modules/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+use-node-version=23.9.0

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "lefthook"
-    ],
-    "executionEnv": {
-      "nodeVersion": "23.9.0"
-    }
+    ]
   }
 }


### PR DESCRIPTION
This pull request resolves #48 by specifying the Node.js version using the `use-node-version` option in the `.npmrc` file.