### PR TITLE
Move Built Dependencies Config to `pnpm-workspace.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,5 @@
   "engines": {
     "node": ">=23",
     "pnpm": ">=10"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - lefthook


### PR DESCRIPTION
This pull request resolves #51 by moving the `onlyBuiltDependencies` config from the `package.json` file to the `pnpm-workspace.yaml` file.