### PR TITLE
Remove Ubuntu 20.04 from CI Tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ jobs:
           - ubuntu-24.04-arm
           - ubuntu-22.04
           - ubuntu-22.04-arm
-          - ubuntu-20.04
           - macos-15
           - macos-14
           - macos-13


### PR DESCRIPTION
This pull request resolves #53 by removing Ubuntu 20.04 from the CI tests.