### PR TITLE
Update Lefthook Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,17 +19,16 @@ jobs:
         run: pnpm install
 
       - name: Check Formatting
-        run: |
-          pnpm format
-          git diff && git diff-index --quiet --exit-code HEAD
+        run: pnpm prettier --check .
 
       - name: Check Lint
-        run: pnpm lint
+        run: pnpm eslint
+
+      - name: Check Types
+        run: pnpm tsc --noEmit
 
       - name: Test Action
         run: pnpm test
 
       - name: Build Action
-        run: |
-          pnpm build
-          git diff && git diff-index --quiet --exit-code HEAD
+        run: pnpm rollup -c && git diff --exit-code dist

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,17 +1,40 @@
 pre-commit:
+  piped: true
   jobs:
-    - run: pnpm prettier --write --cache --ignore-unknown {staged_files}
-      stage_fixed: true
+    - name: install dependencies
+      run: pnpm install
+      glob:
+        - .npmrc
+        - package.json
+        - pnpm-lock.yaml
+        - pnpm-workspace.yaml
 
-    - run: pnpm eslint --no-warn-ignored {staged_files}
+    - name: fix formatting
+      run: pnpm prettier --write --ignore-unknown {staged_files}
 
-    - run: pnpm rollup -c && git add dist
+    - name: fix lint
+      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+
+    - name: check types
+      run: pnpm tsc --noEmit
+      glob:
+        - src/*.ts
+        - .npmrc
+        - pnpm-lock.yaml
+        - tsconfig.json
+      exclude:
+        - src/*.test.ts
+
+    - name: build action
+      run: pnpm rollup -c
       glob:
         - dist/*
         - src/*.ts
-        - rollup.config.js
-        - tsconfig.json
+        - .npmrc
         - pnpm-lock.yaml
+        - tsconfig.json
       exclude:
         - src/*.test.ts
-      stage_fixed: true
+
+    - name: check diff
+      run: git diff --exit-code dist {staged_files}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rollup -c",
-    "format": "prettier --write --cache .",
-    "lint": "eslint",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request resolves #57 by updating the [Lefthook](https://lefthook.dev/) configuration in the `lefthook.yml` file. In doing so, this change also removes the `build`, `format`, and `lint` scripts as they are no longer necessary.