### PR TITLE
Configure TypeScript to Cover All Files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm eslint
 
       - name: Check Types
-        run: pnpm tsc --noEmit
+        run: pnpm tsc
 
       - name: Test Action
         run: pnpm test

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,12 +18,10 @@ pre-commit:
     - name: check types
       run: pnpm tsc --noEmit
       glob:
-        - src/*.ts
+        - "*.ts"
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json
-      exclude:
-        - src/*.test.ts
 
     - name: build action
       run: pnpm rollup -c

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,7 +16,7 @@ pre-commit:
       run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check types
-      run: pnpm tsc --noEmit
+      run: pnpm tsc
       glob:
         - "*.ts"
         - .npmrc

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -7,9 +7,9 @@ import {
   downloadPnpm,
   resolvePnpmVersion,
   setupPnpm,
-} from "./pnpm";
+} from "./pnpm.js";
 
-import { downloadFile } from "./download";
+import { downloadFile } from "./download.js";
 
 vi.mock("gha-utils", () => ({
   addPath: vi.fn().mockResolvedValue(undefined),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "@tsconfig/node20",
-  "include": ["src"],
-  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
     "module": "node16"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node20",
   "compilerOptions": {
-    "module": "node16"
+    "module": "node16",
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This pull request resolves #63 by modifying the TypeScript configuration to cover all files and not to emit compiled files.