### PR TITLE
Strict TypeScript ESLint configuration

### DIFF
--- a/dist/main.bundle.mjs
+++ b/dist/main.bundle.mjs
@@ -102,7 +102,7 @@ async function downloadFile(url, dest) {
     return new Promise((resolve, reject) => {
         const curl = spawn("curl", ["-fLSs", "--output", dest, url]);
         const chunks = [];
-        curl.stderr?.on("data", (chunk) => chunks.push(chunk));
+        curl.stderr.on("data", (chunk) => chunks.push(chunk));
         curl.on("error", reject);
         curl.on("close", (code) => {
             if (code === 0) {
@@ -116,7 +116,10 @@ async function downloadFile(url, dest) {
 }
 
 async function createPnpmHome(version) {
-    const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE, "pnpm", version);
+    let pnpmHome = path.join("pnpm", version);
+    if (process.env.RUNNER_TOOL_CACHE) {
+        pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE, "pnpm", version);
+    }
     await fsPromises.mkdir(pnpmHome, { recursive: true });
     return pnpmHome;
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,20 @@
 import eslint from "@eslint/js";
+import { globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default [
+export default tseslint.config(
+  globalIgnores(["dist"]),
   eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...tseslint.configs.stylistic,
-  { ignores: ["dist"] },
-];
+  tseslint.configs.strictTypeChecked,
+  tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+);

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ["eslint.config.js", "rollup.config.js"],
+          allowDefaultProject: ["rollup.config.js"],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^24.0.4",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.29.0",
+    "jiti": "^2.4.2",
     "lefthook": "^1.11.14",
     "prettier": "^3.6.1",
     "rollup": "^4.44.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,10 +29,13 @@ importers:
         version: 24.0.4
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@24.0.4))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.0.4)(jiti@2.4.2))
       eslint:
         specifier: ^9.29.0
-        version: 9.29.0
+        version: 9.29.0(jiti@2.4.2)
+      jiti:
+        specifier: ^2.4.2
+        version: 2.4.2
       lefthook:
         specifier: ^1.11.14
         version: 1.11.14
@@ -47,10 +50,10 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.35.0
-        version: 8.35.0(eslint@9.29.0)(typescript@5.8.3)
+        version: 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.0.4)
+        version: 3.2.4(@types/node@24.0.4)(jiti@2.4.2)
 
 packages:
 
@@ -913,6 +916,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -1454,9 +1461,9 @@ snapshots:
   '@esbuild/win32-x64@0.24.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@2.4.2))':
     dependencies:
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -1665,15 +1672,15 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.35.0
-      '@typescript-eslint/type-utils': 8.35.0(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.0
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -1682,14 +1689,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.35.0(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.35.0
       '@typescript-eslint/types': 8.35.0
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.0
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1712,12 +1719,12 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.35.0(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.0(eslint@9.29.0)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
       debug: 4.4.1
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1741,13 +1748,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.35.0(eslint@9.29.0)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@typescript-eslint/scope-manager': 8.35.0
       '@typescript-eslint/types': 8.35.0
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
-      eslint: 9.29.0
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1757,7 +1764,7 @@ snapshots:
       '@typescript-eslint/types': 8.35.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.0.4))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.0.4)(jiti@2.4.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -1772,7 +1779,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.0.4)
+      vitest: 3.2.4(@types/node@24.0.4)(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -1784,13 +1791,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.1.0(@types/node@24.0.4))':
+  '@vitest/mocker@3.2.4(vite@6.1.0(@types/node@24.0.4)(jiti@2.4.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.1.0(@types/node@24.0.4)
+      vite: 6.1.0(@types/node@24.0.4)(jiti@2.4.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1956,9 +1963,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.29.0:
+  eslint@9.29.0(jiti@2.4.2):
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@2.4.2))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.1
       '@eslint/config-helpers': 0.2.3
@@ -1993,6 +2000,8 @@ snapshots:
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2160,6 +2169,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jiti@2.4.2: {}
 
   js-tokens@9.0.1: {}
 
@@ -2456,12 +2467,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.35.0(eslint@9.29.0)(typescript@5.8.3):
+  typescript-eslint@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0)(typescript@5.8.3))(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.35.0(eslint@9.29.0)(typescript@5.8.3)
-      eslint: 9.29.0
+      '@typescript-eslint/eslint-plugin': 8.35.0(@typescript-eslint/parser@8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.35.0(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint: 9.29.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2474,13 +2485,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@24.0.4):
+  vite-node@3.2.4(@types/node@24.0.4)(jiti@2.4.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.1.0(@types/node@24.0.4)
+      vite: 6.1.0(@types/node@24.0.4)(jiti@2.4.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2495,7 +2506,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.1.0(@types/node@24.0.4):
+  vite@6.1.0(@types/node@24.0.4)(jiti@2.4.2):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
@@ -2503,12 +2514,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.4
       fsevents: 2.3.3
+      jiti: 2.4.2
 
-  vitest@3.2.4(@types/node@24.0.4):
+  vitest@3.2.4(@types/node@24.0.4)(jiti@2.4.2):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.1.0(@types/node@24.0.4))
+      '@vitest/mocker': 3.2.4(vite@6.1.0(@types/node@24.0.4)(jiti@2.4.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2526,8 +2538,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.1.0(@types/node@24.0.4)
-      vite-node: 3.2.4(@types/node@24.0.4)
+      vite: 6.1.0(@types/node@24.0.4)(jiti@2.4.2)
+      vite-node: 3.2.4(@types/node@24.0.4)(jiti@2.4.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.0.4

--- a/src/download.ts
+++ b/src/download.ts
@@ -5,7 +5,7 @@ export async function downloadFile(url: string, dest: string): Promise<void> {
     const curl = spawn("curl", ["-fLSs", "--output", dest, url]);
 
     const chunks: Uint8Array[] = [];
-    curl.stderr?.on("data", (chunk) => chunks.push(chunk));
+    curl.stderr.on("data", (chunk: Buffer) => chunks.push(chunk));
 
     curl.on("error", reject);
     curl.on("close", (code) => {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -16,7 +16,7 @@ vi.mock("./platform.js", () => ({
 vi.mock("./pnpm.js", () => ({
   createPnpmHome: vi.fn().mockResolvedValue("/pnpm"),
   downloadPnpm: vi.fn().mockResolvedValue(undefined),
-  resolvePnpmVersion: vi.fn().mockImplementation(async (version) => version),
+  resolvePnpmVersion: vi.fn().mockImplementation((version: string) => version),
   setupPnpm: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -5,7 +5,10 @@ import { downloadFile } from "./download.js";
 import type { Architecture, Platform } from "./platform.js";
 
 export async function createPnpmHome(version: string): Promise<string> {
-  const pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE!, "pnpm", version);
+  let pnpmHome = path.join("pnpm", version);
+  if (process.env.RUNNER_TOOL_CACHE) {
+    pnpmHome = path.join(process.env.RUNNER_TOOL_CACHE, "pnpm", version);
+  }
   await fsPromises.mkdir(pnpmHome, { recursive: true });
   return pnpmHome;
 }


### PR DESCRIPTION
This pull request resolves #65 by enabling a stricter TypeScript configuration. This change also convert the ESLint configuration to TypeScript.