### PR TITLE
Remove Windows 2019 from CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,6 @@ jobs:
           - macos-13
           - windows-2025
           - windows-2022
-          - windows-2019
     steps:
       - name: Checkout Action
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This pull request resolves #73 by removing Windows 2019 from the test workflow.