### PR TITLE
Remove Testing on macOS 13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,6 @@ jobs:
           - ubuntu-22.04-arm
           - macos-15
           - macos-14
-          - macos-13
           - windows-2025
           - windows-2022
     steps:


### PR DESCRIPTION
This pull request resolves #107 by removing the `test.yaml` workflow from testing on macOS 13.