### PR TITLE
Remove glob-based filtering from Lefthook jobs

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -5,33 +5,15 @@ pre-commit:
   jobs:
     - name: install dependencies
       run: pnpm install
-      glob:
-        - .npmrc
-        - package.json
-        - pnpm-lock.yaml
-        - pnpm-workspace.yaml
 
     - name: fix formatting
-      run: pnpm prettier --write --ignore-unknown {staged_files}
+      run: pnpm prettier --write .
 
     - name: fix lint
-      run: pnpm eslint --no-warn-ignored --fix {staged_files}
+      run: pnpm eslint --fix
 
     - name: check types
       run: pnpm tsc
-      glob:
-        - "*.ts"
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
 
     - name: build action
       run: pnpm rollup -c
-      glob:
-        - dist/*
-        - src/*.ts
-        - .npmrc
-        - pnpm-lock.yaml
-        - tsconfig.json
-      exclude:
-        - src/*.test.ts


### PR DESCRIPTION
Removes glob patterns used for filtering Lefthook jobs, simplifying the configuration.

Previously, jobs like `fix formatting`, `fix lint`, `check types`, and `build action` used `glob` (and `exclude`) filters to run only when relevant files were staged. This change removes those filters so all jobs always run unconditionally on pre-commit.

Closes #211.