### PR TITLE
Make `.gitignore` rules for dot-prefixed files more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .*
-!.git*
+!.github/
+!.gitattributes
+!.gitignore
 !.npmrc
 !.prettierignore
 


### PR DESCRIPTION
This pull request resolves #217 by making the rules for including dot-prefixed files in `.gitignore` more specific.