### PR TITLE
Remove redundant `test` script from `package.json`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         run: lefthook run pre-commit --all-files
 
       - name: Test
-        run: pnpm test
+        run: pnpm vitest run
 
   test:
     name: Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```sh
-pnpm test                 # run all tests (Vitest)
-pnpm test <file>          # run a single test file
+pnpm vitest run           # run all tests (Vitest)
+pnpm vitest run <file>    # run a single test file
 pnpm tsc                  # type check
 pnpm eslint .             # lint
 pnpm prettier --check .   # check formatting

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "scripts": {
-    "test": "vitest run"
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@rollup/plugin-node-resolve": "^16.0.3",


### PR DESCRIPTION
Removes the `test` script from `package.json`, which was just an alias for `vitest run`. The command is concise enough to invoke directly, so the alias adds no value.

## Changes

- Remove `scripts.test` from `package.json`
- Update CI workflow to call `pnpm vitest run` directly
- Update `CLAUDE.md` to reference `pnpm vitest run`

Closes #229 