### PR TITLE
Add Prettier plugin for organizing imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 !.gitignore
 !.npmrc
 !.prettierignore
+!.prettierrc.json
 
 node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,8 +1,8 @@
 import { EOL, arch, platform } from 'node:os';
-import { delimiter, extname, join } from 'node:path';
-import { appendFile, mkdir, chmod, rm } from 'node:fs/promises';
-import 'node:fs';
 import { spawn } from 'node:child_process';
+import 'node:fs';
+import { appendFile, mkdir, chmod, rm } from 'node:fs/promises';
+import { delimiter, extname, join } from 'node:path';
 
 /**
  * Logs an information message in GitHub Actions.
@@ -24,67 +24,57 @@ function logError(err, options) {
     process.stdout.write(`::error${params}::${message}${EOL}`);
 }
 
-async function resolvePnpmVersionFromResponse(version, res) {
-    if (!res.ok) {
-        throw new Error(`Failed to fetch version registry: ${res.statusText}`);
-    }
-    const data = await res.json();
-    if (typeof data === "object" && data !== null) {
-        if ("dist-tags" in data &&
-            typeof data["dist-tags"] === "object" &&
-            data["dist-tags"] !== null) {
-            const distTags = data["dist-tags"];
-            if (version in distTags && typeof distTags[version] === "string") {
-                return distTags[version];
-            }
+function exec(command, args, opts) {
+    return new Promise((resolve, reject) => {
+        const stdoutMode = opts?.stdout ?? "inherit";
+        const stderrMode = opts?.stderr ?? "inherit";
+        const proc = spawn(command, args, {
+            stdio: [
+                "inherit",
+                stdoutMode === "inherit"
+                    ? "inherit"
+                    : stdoutMode === "capture"
+                        ? "pipe"
+                        : "ignore",
+                stderrMode === "inherit"
+                    ? "inherit"
+                    : stderrMode === "capture"
+                        ? "pipe"
+                        : "ignore",
+            ],
+        });
+        const stdoutChunks = [];
+        if (proc.stdout !== null) {
+            proc.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
         }
-        if ("versions" in data &&
-            typeof data.versions === "object" &&
-            data.versions !== null) {
-            if (version in data.versions)
-                return version;
+        const stderrChunks = [];
+        if (proc.stderr !== null) {
+            proc.stderr.on("data", (chunk) => stderrChunks.push(chunk));
         }
-    }
-    throw new Error(`Unknown version: ${version}`);
-}
-async function resolvePnpmVersion(version) {
-    const res = await fetch("https://registry.npmjs.org/@pnpm/exe");
-    return resolvePnpmVersionFromResponse(version, res);
-}
-function getPnpmDownloadUrl({ version, platform, arch, }) {
-    const match = /^(\d+)/.exec(version);
-    if (!match)
-        throw new Error(`Invalid version: ${version}`);
-    const major = parseInt(match[1], 10);
-    let os;
-    switch (platform) {
-        case "linux":
-            os = "linux";
-            break;
-        case "darwin":
-            os = "macos";
-            break;
-        case "win32":
-            os = "win";
-            break;
-        default:
-            throw new Error(`Unsupported platform: ${platform}`);
-    }
-    switch (arch) {
-        case "x64":
-            if (platform === "darwin" && major >= 11) {
-                throw new Error("pnpm does not provide x64 macOS binaries for version 11 and above");
+        proc.on("error", reject);
+        proc.on("close", (code) => {
+            if (code === 0) {
+                if (stdoutMode === "capture" || stderrMode === "capture") {
+                    const result = {};
+                    if (stdoutMode === "capture") {
+                        result.stdout = Buffer.concat(stdoutChunks).toString();
+                    }
+                    if (stderrMode === "capture") {
+                        result.stderr = Buffer.concat(stderrChunks).toString();
+                    }
+                    resolve(result);
+                }
+                else {
+                    resolve();
+                }
             }
-            break;
-        case "arm64":
-            break;
-        default:
-            throw new Error(`Unsupported arch: ${arch}`);
-    }
-    const file = major >= 11
-        ? `pnpm-${platform}-${arch}${platform == "win32" ? ".zip" : ".tar.gz"}`
-        : `pnpm-${os}-${arch}${platform === "win32" ? ".exe" : ""}`;
-    return new URL(`https://github.com/pnpm/pnpm/releases/download/v${version}/${file}`);
+            else {
+                reject(new Error(code !== null
+                    ? `Process "${command}" exited with code ${code.toString()}`
+                    : `Process "${command}" was terminated by a signal`));
+            }
+        });
+    });
 }
 
 /**
@@ -163,59 +153,6 @@ async function addPath(sysPath) {
     await appendFile(getGitHubPath(), `${sysPath}${EOL}`);
 }
 
-function exec(command, args, opts) {
-    return new Promise((resolve, reject) => {
-        const stdoutMode = opts?.stdout ?? "inherit";
-        const stderrMode = opts?.stderr ?? "inherit";
-        const proc = spawn(command, args, {
-            stdio: [
-                "inherit",
-                stdoutMode === "inherit"
-                    ? "inherit"
-                    : stdoutMode === "capture"
-                        ? "pipe"
-                        : "ignore",
-                stderrMode === "inherit"
-                    ? "inherit"
-                    : stderrMode === "capture"
-                        ? "pipe"
-                        : "ignore",
-            ],
-        });
-        const stdoutChunks = [];
-        if (proc.stdout !== null) {
-            proc.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
-        }
-        const stderrChunks = [];
-        if (proc.stderr !== null) {
-            proc.stderr.on("data", (chunk) => stderrChunks.push(chunk));
-        }
-        proc.on("error", reject);
-        proc.on("close", (code) => {
-            if (code === 0) {
-                if (stdoutMode === "capture" || stderrMode === "capture") {
-                    const result = {};
-                    if (stdoutMode === "capture") {
-                        result.stdout = Buffer.concat(stdoutChunks).toString();
-                    }
-                    if (stderrMode === "capture") {
-                        result.stderr = Buffer.concat(stderrChunks).toString();
-                    }
-                    resolve(result);
-                }
-                else {
-                    resolve();
-                }
-            }
-            else {
-                reject(new Error(code !== null
-                    ? `Process "${command}" exited with code ${code.toString()}`
-                    : `Process "${command}" was terminated by a signal`));
-            }
-        });
-    });
-}
-
 async function extractArchive(archiveFile, outputDir) {
     const ext = extname(archiveFile);
     switch (ext) {
@@ -234,6 +171,69 @@ async function extractArchive(archiveFile, outputDir) {
         default:
             throw new Error(`Unsupported archive extension: ${ext}`);
     }
+}
+
+async function resolvePnpmVersionFromResponse(version, res) {
+    if (!res.ok) {
+        throw new Error(`Failed to fetch version registry: ${res.statusText}`);
+    }
+    const data = await res.json();
+    if (typeof data === "object" && data !== null) {
+        if ("dist-tags" in data &&
+            typeof data["dist-tags"] === "object" &&
+            data["dist-tags"] !== null) {
+            const distTags = data["dist-tags"];
+            if (version in distTags && typeof distTags[version] === "string") {
+                return distTags[version];
+            }
+        }
+        if ("versions" in data &&
+            typeof data.versions === "object" &&
+            data.versions !== null) {
+            if (version in data.versions)
+                return version;
+        }
+    }
+    throw new Error(`Unknown version: ${version}`);
+}
+async function resolvePnpmVersion(version) {
+    const res = await fetch("https://registry.npmjs.org/@pnpm/exe");
+    return resolvePnpmVersionFromResponse(version, res);
+}
+function getPnpmDownloadUrl({ version, platform, arch, }) {
+    const match = /^(\d+)/.exec(version);
+    if (!match)
+        throw new Error(`Invalid version: ${version}`);
+    const major = parseInt(match[1], 10);
+    let os;
+    switch (platform) {
+        case "linux":
+            os = "linux";
+            break;
+        case "darwin":
+            os = "macos";
+            break;
+        case "win32":
+            os = "win";
+            break;
+        default:
+            throw new Error(`Unsupported platform: ${platform}`);
+    }
+    switch (arch) {
+        case "x64":
+            if (platform === "darwin" && major >= 11) {
+                throw new Error("pnpm does not provide x64 macOS binaries for version 11 and above");
+            }
+            break;
+        case "arm64":
+            break;
+        default:
+            throw new Error(`Unsupported arch: ${arch}`);
+    }
+    const file = major >= 11
+        ? `pnpm-${platform}-${arch}${platform == "win32" ? ".zip" : ".tar.gz"}`
+        : `pnpm-${os}-${arch}${platform === "win32" ? ".exe" : ""}`;
+    return new URL(`https://github.com/pnpm/pnpm/releases/download/v${version}/${file}`);
 }
 
 async function setupPnpmAction() {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ghakit": "^1.0.0",
     "jiti": "^2.7.0",
     "prettier": "^3.8.3",
+    "prettier-plugin-organize-imports": "^4.3.0",
     "rollup": "^4.60.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      prettier-plugin-organize-imports:
+        specifier: ^4.3.0
+        version: 4.3.0(prettier@3.8.3)(typescript@6.0.3)
       rollup:
         specifier: ^4.60.3
         version: 4.60.3
@@ -918,6 +921,16 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-organize-imports@4.3.0:
+    resolution: {integrity: sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -1878,6 +1891,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.3.0(prettier@3.8.3)(typescript@6.0.3):
+    dependencies:
+      prettier: 3.8.3
+      typescript: 6.0.3
 
   prettier@3.8.3: {}
 

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,6 +1,11 @@
+import { addPath, getInput, setEnv } from "ghakit/io";
+import { logInfo } from "ghakit/log";
+import { getRunnerToolCache } from "ghakit/vars";
 import { execFile } from "node:child_process";
 import { mkdir, rm } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
+import { chdir } from "node:process";
 import { promisify } from "node:util";
 import {
   afterAll,
@@ -12,11 +17,6 @@ import {
   vi,
 } from "vitest";
 import { setupPnpmAction } from "./action.js";
-import { chdir } from "node:process";
-import { homedir } from "node:os";
-import { logInfo } from "ghakit/log";
-import { addPath, getInput, setEnv } from "ghakit/io";
-import { getRunnerToolCache } from "ghakit/vars";
 import { resolvePnpmVersion } from "./pnpm.js";
 
 const execFileAsync = promisify(execFile);

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,12 +1,12 @@
-import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
-import { extname, join } from "node:path";
+import { exec } from "ghakit/exec";
+import { addPath, getInput, setEnv } from "ghakit/io";
+import { logInfo } from "ghakit/log";
+import { getRunnerToolCache } from "ghakit/vars";
 import { chmod, mkdir, rm } from "node:fs/promises";
 import { arch, platform } from "node:os";
-import { logInfo } from "ghakit/log";
-import { addPath, getInput, setEnv } from "ghakit/io";
-import { getRunnerToolCache } from "ghakit/vars";
-import { exec } from "ghakit/exec";
+import { extname, join } from "node:path";
 import { extractArchive } from "./archive.js";
+import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
 
 export async function setupPnpmAction() {
   logInfo("Resolve pnpm version");

--- a/src/archive.test.ts
+++ b/src/archive.test.ts
@@ -1,9 +1,9 @@
+import { execFile } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { chdir } from "node:process";
 import { promisify } from "node:util";
-import { execFile } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { extractArchive } from "./archive.js";
 
 const execFileAsync = promisify(execFile);


### PR DESCRIPTION
This pull request resolves #233 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.