### PR TITLE
Add support for pnpm v11 archive-based releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,19 +51,24 @@ jobs:
             dist
           sparse-checkout-cone-mode: false
 
-      # TODO: Re-enable latest pnpm setup after
-      # https://github.com/threeal/setup-pnpm-action/issues/195 is fixed.
-      #
-      # - name: Setup pnpm
-      #   uses: ./setup-pnpm-action
-      #
-      # - name: Check pnpm
-      #   run: pnpm --version
+      - name: Setup pnpm
+        uses: ./setup-pnpm-action
+
+      - name: Verify latest pnpm version
+        shell: bash
+        run: |
+          version="$(pnpm --version)"
+          echo "$version"
+          test "$version" != "10.34.0"
 
       - name: Setup pnpm with version input
         uses: ./setup-pnpm-action
         with:
-          version: 9.15.5
+          version: 10.34.0
 
-      - name: Check pnpm
-        run: pnpm --version
+      - name: Verify specified pnpm version
+        shell: bash
+        run: |
+          version="$(pnpm --version)"
+          echo "$version"
+          test "$version" = "10.34.0"

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,6 +1,6 @@
-import { EOL, platform, arch } from 'node:os';
-import { delimiter, join } from 'node:path';
-import { appendFile, mkdir, chmod } from 'node:fs/promises';
+import { EOL, arch, platform } from 'node:os';
+import { delimiter, extname, join } from 'node:path';
+import { appendFile, mkdir, chmod, rm } from 'node:fs/promises';
 import 'node:fs';
 import { spawn } from 'node:child_process';
 
@@ -51,10 +51,11 @@ async function resolvePnpmVersion(version) {
     const res = await fetch("https://registry.npmjs.org/@pnpm/exe");
     return resolvePnpmVersionFromResponse(version, res);
 }
-function getPnpmBinaryName(platform) {
-    return platform === "win32" ? "pnpm.exe" : "pnpm";
-}
 function getPnpmDownloadUrl({ version, platform, arch, }) {
+    const match = /^(\d+)/.exec(version);
+    if (!match)
+        throw new Error(`Invalid version: ${version}`);
+    const major = parseInt(match[1], 10);
     let os;
     switch (platform) {
         case "linux":
@@ -69,19 +70,21 @@ function getPnpmDownloadUrl({ version, platform, arch, }) {
         default:
             throw new Error(`Unsupported platform: ${platform}`);
     }
-    let archStr;
     switch (arch) {
         case "x64":
-            archStr = "x64";
+            if (platform === "darwin" && major >= 11) {
+                throw new Error("pnpm does not provide x64 macOS binaries for version 11 and above");
+            }
             break;
         case "arm64":
-            archStr = "arm64";
             break;
         default:
             throw new Error(`Unsupported arch: ${arch}`);
     }
-    const ext = platform === "win32" ? ".exe" : "";
-    return `https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-${archStr}${ext}`;
+    const file = major >= 11
+        ? `pnpm-${platform}-${arch}${platform == "win32" ? ".zip" : ".tar.gz"}`
+        : `pnpm-${os}-${arch}${platform === "win32" ? ".exe" : ""}`;
+    return new URL(`https://github.com/pnpm/pnpm/releases/download/v${version}/${file}`);
 }
 
 /**
@@ -162,11 +165,21 @@ async function addPath(sysPath) {
 
 function exec(command, args, opts) {
     return new Promise((resolve, reject) => {
+        const stdoutMode = opts?.stdout ?? "inherit";
+        const stderrMode = opts?.stderr ?? "inherit";
         const proc = spawn(command, args, {
             stdio: [
                 "inherit",
-                "ignore",
-                "ignore",
+                stdoutMode === "inherit"
+                    ? "inherit"
+                    : stdoutMode === "capture"
+                        ? "pipe"
+                        : "ignore",
+                stderrMode === "inherit"
+                    ? "inherit"
+                    : stderrMode === "capture"
+                        ? "pipe"
+                        : "ignore",
             ],
         });
         const stdoutChunks = [];
@@ -180,7 +193,17 @@ function exec(command, args, opts) {
         proc.on("error", reject);
         proc.on("close", (code) => {
             if (code === 0) {
-                {
+                if (stdoutMode === "capture" || stderrMode === "capture") {
+                    const result = {};
+                    if (stdoutMode === "capture") {
+                        result.stdout = Buffer.concat(stdoutChunks).toString();
+                    }
+                    if (stderrMode === "capture") {
+                        result.stderr = Buffer.concat(stderrChunks).toString();
+                    }
+                    resolve(result);
+                }
+                else {
                     resolve();
                 }
             }
@@ -193,22 +216,66 @@ function exec(command, args, opts) {
     });
 }
 
+async function extractArchive(archiveFile, outputDir) {
+    const ext = extname(archiveFile);
+    switch (ext) {
+        case ".gz":
+            await exec("tar", ["-xzf", archiveFile, "-C", outputDir], {
+                stdout: "silent",
+                stderr: "silent",
+            });
+            break;
+        case ".zip":
+            await exec("unzip", [archiveFile, "-d", outputDir], {
+                stdout: "silent",
+                stderr: "silent",
+            });
+            break;
+        default:
+            throw new Error(`Unsupported archive extension: ${ext}`);
+    }
+}
+
 async function setupPnpmAction() {
     logInfo("Resolve pnpm version");
     const version = await resolvePnpmVersion(getInput("version").trim());
     logInfo("Create pnpm home");
     const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
     await mkdir(pnpmHome, { recursive: true });
-    const binPath = join(pnpmHome, getPnpmBinaryName(platform()));
-    const url = getPnpmDownloadUrl({
+    const dlUrl = getPnpmDownloadUrl({
         version,
         platform: platform(),
         arch: arch(),
     });
+    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
+    let dlOut;
+    const dlFileExt = extname(dlFile);
+    switch (dlFileExt) {
+        case ".gz":
+        case ".zip":
+            dlOut = join(pnpmHome, dlFile);
+            break;
+        default:
+            dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
+    }
     logInfo(`Download pnpm ${version}`);
-    await exec("curl", ["-fLSs", "--output", binPath, url]);
-    logInfo("Set file permissions");
-    await chmod(binPath, "755");
+    await exec("curl", ["-fLSs", "--output", dlOut, dlUrl.href], {
+        stdout: "silent",
+        stderr: "silent",
+    });
+    const dlOutExt = extname(dlOut);
+    switch (dlOutExt) {
+        case ".gz":
+        case ".zip":
+            logInfo("Extract archive");
+            await extractArchive(dlOut, pnpmHome);
+            logInfo("Remove archive");
+            await rm(dlOut);
+            break;
+        default:
+            logInfo("Set file permissions");
+            await chmod(dlOut, "755");
+    }
     logInfo("Add pnpm to PATH");
     await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);
 }

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os";
 import { logInfo } from "ghakit/log";
 import { addPath, getInput, setEnv } from "ghakit/io";
 import { getRunnerToolCache } from "ghakit/vars";
+import { resolvePnpmVersion } from "./pnpm.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -42,37 +43,66 @@ afterAll(() => rm(tmpDir, { force: true, recursive: true }));
 describe("setupPnpmAction", () => {
   let logs: string[] = [];
 
+  const assertPnpmVersion = async (version: string, pnpmHome: string) => {
+    const { stdout, stderr } = await execFileAsync("pnpm", ["--version"], {
+      env: {
+        PATH: pnpmHome,
+      },
+    });
+    expect(stdout.trim()).toBe(version);
+    expect(stderr.trim()).toBe("");
+  };
+
   beforeEach(() => {
     logs = [];
     vi.mocked(logInfo).mockImplementation((message) => logs.push(message));
     vi.mocked(getRunnerToolCache).mockReturnValue(join(tmpDir, "cache"));
   });
 
-  test("downloads specified version", { timeout: 60000 }, async () => {
-    vi.mocked(getInput).mockReturnValue("10.34.0");
+  test("downloads latest version", { timeout: 60000 }, async () => {
+    vi.mocked(getInput).mockReturnValue("latest");
+    const version = await resolvePnpmVersion("latest");
 
     await setupPnpmAction();
 
     expect(logs).toStrictEqual([
       "Resolve pnpm version",
       "Create pnpm home",
-      "Download pnpm 10.34.0",
-      "Set file permissions",
+      `Download pnpm ${version}`,
+      "Extract archive",
+      "Remove archive",
       "Add pnpm to PATH",
     ]);
 
-    const pnpmHome = join(tmpDir, "cache/pnpm/10.34.0");
+    const pnpmHome = join(tmpDir, "cache", "pnpm", version);
     expect(vi.mocked(setEnv).mock.calls).toStrictEqual([
       ["PNPM_HOME", pnpmHome],
     ]);
     expect(vi.mocked(addPath).mock.calls).toStrictEqual([[pnpmHome]]);
 
-    const { stdout, stderr } = await execFileAsync("pnpm", ["--version"], {
-      env: {
-        PATH: pnpmHome,
-      },
-    });
-    expect(stdout.trim()).toBe("10.34.0");
-    expect(stderr.trim()).toBe("");
+    await assertPnpmVersion(version, pnpmHome);
+  });
+
+  test("downloads specified version", { timeout: 60000 }, async () => {
+    const version = "10.34.0";
+    vi.mocked(getInput).mockReturnValue(version);
+
+    await setupPnpmAction();
+
+    expect(logs).toStrictEqual([
+      "Resolve pnpm version",
+      "Create pnpm home",
+      `Download pnpm ${version}`,
+      "Set file permissions",
+      "Add pnpm to PATH",
+    ]);
+
+    const pnpmHome = join(tmpDir, "cache", "pnpm", version);
+    expect(vi.mocked(setEnv).mock.calls).toStrictEqual([
+      ["PNPM_HOME", pnpmHome],
+    ]);
+    expect(vi.mocked(addPath).mock.calls).toStrictEqual([[pnpmHome]]);
+
+    await assertPnpmVersion(version, pnpmHome);
   });
 });

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,15 +1,12 @@
-import {
-  getPnpmDownloadUrl,
-  getPnpmBinaryName,
-  resolvePnpmVersion,
-} from "./pnpm.js";
-import { join } from "node:path";
-import { chmod, mkdir } from "node:fs/promises";
+import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
+import { extname, join } from "node:path";
+import { chmod, mkdir, rm } from "node:fs/promises";
 import { arch, platform } from "node:os";
 import { logInfo } from "ghakit/log";
 import { addPath, getInput, setEnv } from "ghakit/io";
 import { getRunnerToolCache } from "ghakit/vars";
 import { exec } from "ghakit/exec";
+import { extractArchive } from "./archive.js";
 
 export async function setupPnpmAction() {
   logInfo("Resolve pnpm version");
@@ -19,21 +16,47 @@ export async function setupPnpmAction() {
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
   await mkdir(pnpmHome, { recursive: true });
 
-  const binPath = join(pnpmHome, getPnpmBinaryName(platform()));
-  const url = getPnpmDownloadUrl({
+  const dlUrl = getPnpmDownloadUrl({
     version,
     platform: platform(),
     arch: arch(),
   });
 
+  const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
+
+  let dlOut: string;
+  const dlFileExt = extname(dlFile);
+  switch (dlFileExt) {
+    case ".gz":
+    case ".zip":
+      dlOut = join(pnpmHome, dlFile);
+      break;
+
+    default:
+      dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
+  }
+
   logInfo(`Download pnpm ${version}`);
-  await exec("curl", ["-fLSs", "--output", binPath, url], {
+  await exec("curl", ["-fLSs", "--output", dlOut, dlUrl.href], {
     stdout: "silent",
     stderr: "silent",
   });
 
-  logInfo("Set file permissions");
-  await chmod(binPath, "755");
+  const dlOutExt = extname(dlOut);
+  switch (dlOutExt) {
+    case ".gz":
+    case ".zip":
+      logInfo("Extract archive");
+      await extractArchive(dlOut, pnpmHome);
+
+      logInfo("Remove archive");
+      await rm(dlOut);
+      break;
+
+    default:
+      logInfo("Set file permissions");
+      await chmod(dlOut, "755");
+  }
 
   logInfo("Add pnpm to PATH");
   await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);

--- a/src/archive.test.ts
+++ b/src/archive.test.ts
@@ -1,0 +1,60 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { chdir } from "node:process";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+import { extractArchive } from "./archive.js";
+
+const execFileAsync = promisify(execFile);
+
+const tmpDir = resolve(
+  import.meta.dirname,
+  `.${basename(import.meta.filename)}.tmp`,
+);
+
+beforeAll(async () => {
+  await rm(tmpDir, { force: true, recursive: true });
+  await mkdir(tmpDir, { recursive: true });
+  chdir(tmpDir);
+});
+
+afterAll(() => rm(tmpDir, { force: true, recursive: true }));
+
+describe("extractArchive", { concurrent: true }, () => {
+  test("extracts .tar.gz archive", { timeout: 60000 }, async () => {
+    await mkdir(join(tmpDir, "tar", "foo"), { recursive: true });
+    await writeFile(join(tmpDir, "tar", "foo", "bar"), "foo bar");
+
+    const archiveFile = join(tmpDir, "archive.tar.gz");
+    await execFileAsync("tar", ["-czf", archiveFile, "-C", tmpDir, "tar"]);
+    await rm(join(tmpDir, "tar"), { force: true, recursive: true });
+
+    await extractArchive(archiveFile, tmpDir);
+
+    const content = await readFile(join(tmpDir, "tar", "foo", "bar"), "utf-8");
+    expect(content).toBe("foo bar");
+  });
+
+  test("extracts .zip archive", { timeout: 60000 }, async () => {
+    await mkdir(join(tmpDir, "zip", "foo"), { recursive: true });
+    await writeFile(join(tmpDir, "zip", "foo", "bar"), "foo bar");
+
+    const archiveFile = join(tmpDir, "archive.zip");
+    await execFileAsync("zip", ["-r", archiveFile, "zip"], { cwd: tmpDir });
+    await rm(join(tmpDir, "zip"), { force: true, recursive: true });
+
+    await extractArchive(archiveFile, tmpDir);
+
+    const content = await readFile(join(tmpDir, "zip", "foo", "bar"), "utf-8");
+    expect(content).toBe("foo bar");
+  });
+
+  test("throws for unsupported archive extension", async () => {
+    await writeFile("archive.7z", "");
+
+    await expect(extractArchive("archive.7z", tmpDir)).rejects.toThrow(
+      "Unsupported archive extension: .7z",
+    );
+  });
+});

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,0 +1,24 @@
+import { exec } from "ghakit/exec";
+import { extname } from "node:path";
+
+export async function extractArchive(archiveFile: string, outputDir: string) {
+  const ext = extname(archiveFile);
+  switch (ext) {
+    case ".gz":
+      await exec("tar", ["-xzf", archiveFile, "-C", outputDir], {
+        stdout: "silent",
+        stderr: "silent",
+      });
+      break;
+
+    case ".zip":
+      await exec("unzip", [archiveFile, "-d", outputDir], {
+        stdout: "silent",
+        stderr: "silent",
+      });
+      break;
+
+    default:
+      throw new Error(`Unsupported archive extension: ${ext}`);
+  }
+}

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import {
-  getPnpmBinaryName,
   getPnpmDownloadUrl,
   resolvePnpmVersion,
   resolvePnpmVersionFromResponse,
@@ -73,55 +72,70 @@ describe("resolvePnpmVersion", { concurrent: true }, () => {
   });
 });
 
-describe("getPnpmBinaryName", () => {
-  test("returns pnpm for non-Windows platforms", () => {
-    expect(getPnpmBinaryName("linux")).toBe("pnpm");
-    expect(getPnpmBinaryName("darwin")).toBe("pnpm");
-  });
-
-  test("returns pnpm.exe for Windows", () => {
-    expect(getPnpmBinaryName("win32")).toBe("pnpm.exe");
-  });
-});
-
 describe("getPnpmDownloadUrl", { concurrent: true }, () => {
-  const version = "10.34.0";
-
-  const combinations = [
-    { platform: "linux", arch: "x64" },
-    { platform: "linux", arch: "arm64" },
-    { platform: "darwin", arch: "x64" },
-    { platform: "darwin", arch: "arm64" },
-    { platform: "win32", arch: "x64" },
-    { platform: "win32", arch: "arm64" },
-  ] as const;
+  const combinations = ["10.34.0", "11.5.0"]
+    .flatMap((version) =>
+      ["linux", "darwin", "win32"].flatMap((platform) =>
+        ["x64", "arm64"].map((arch) => ({ version, platform, arch })),
+      ),
+    )
+    .filter(
+      ({ version, platform, arch }) =>
+        version !== "11.5.0" || platform !== "darwin" || arch !== "x64",
+    );
 
   test("returns unique URLs for each combination", () => {
-    const urls = combinations.map(({ platform, arch }) =>
+    const urls = combinations.map(({ version, platform, arch }) =>
       getPnpmDownloadUrl({ version, platform, arch }),
     );
     expect(new Set(urls).size).toBe(combinations.length);
   });
 
   test.each(combinations)(
-    "returns accessible URL for $platform/$arch",
+    "returns accessible URL for $version/$platform/$arch",
     { timeout: 30000 },
-    async ({ platform, arch }) => {
+    async ({ version, platform, arch }) => {
       const url = getPnpmDownloadUrl({ version, platform, arch });
       const res = await fetch(url, { method: "HEAD" });
       expect(res.ok).toBe(true);
     },
   );
 
+  test("throws when version is invalid", () => {
+    expect(() =>
+      getPnpmDownloadUrl({ version: "latest", platform: "linux", arch: "x64" }),
+    ).toThrow("Invalid version: latest");
+  });
+
   test("throws when platform is unsupported", () => {
     expect(() =>
-      getPnpmDownloadUrl({ version, platform: "freebsd", arch: "x64" }),
+      getPnpmDownloadUrl({
+        version: "10.34.0",
+        platform: "freebsd",
+        arch: "x64",
+      }),
     ).toThrow("Unsupported platform: freebsd");
   });
 
   test("throws when arch is unsupported", () => {
     expect(() =>
-      getPnpmDownloadUrl({ version, platform: "linux", arch: "ia32" }),
+      getPnpmDownloadUrl({
+        version: "10.34.0",
+        platform: "linux",
+        arch: "ia32",
+      }),
     ).toThrow("Unsupported arch: ia32");
+  });
+
+  test("throws for x64 macOS on version 11 and above", () => {
+    expect(() =>
+      getPnpmDownloadUrl({
+        version: "11.5.0",
+        platform: "darwin",
+        arch: "x64",
+      }),
+    ).toThrow(
+      "pnpm does not provide x64 macOS binaries for version 11 and above",
+    );
   });
 });

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -36,10 +36,6 @@ export async function resolvePnpmVersion(version: string): Promise<string> {
   return resolvePnpmVersionFromResponse(version, res);
 }
 
-export function getPnpmBinaryName(platform: string): string {
-  return platform === "win32" ? "pnpm.exe" : "pnpm";
-}
-
 export function getPnpmDownloadUrl({
   version,
   platform,
@@ -48,7 +44,11 @@ export function getPnpmDownloadUrl({
   version: string;
   platform: string;
   arch: string;
-}): string {
+}): URL {
+  const match = /^(\d+)/.exec(version);
+  if (!match) throw new Error(`Invalid version: ${version}`);
+  const major = parseInt(match[1], 10);
+
   let os: string;
   switch (platform) {
     case "linux":
@@ -64,18 +64,26 @@ export function getPnpmDownloadUrl({
       throw new Error(`Unsupported platform: ${platform}`);
   }
 
-  let archStr: string;
   switch (arch) {
     case "x64":
-      archStr = "x64";
+      if (platform === "darwin" && major >= 11) {
+        throw new Error(
+          "pnpm does not provide x64 macOS binaries for version 11 and above",
+        );
+      }
       break;
     case "arm64":
-      archStr = "arm64";
       break;
     default:
       throw new Error(`Unsupported arch: ${arch}`);
   }
 
-  const ext = platform === "win32" ? ".exe" : "";
-  return `https://github.com/pnpm/pnpm/releases/download/v${version}/pnpm-${os}-${archStr}${ext}`;
+  const file =
+    major >= 11
+      ? `pnpm-${platform}-${arch}${platform == "win32" ? ".zip" : ".tar.gz"}`
+      : `pnpm-${os}-${arch}${platform === "win32" ? ".exe" : ""}`;
+
+  return new URL(
+    `https://github.com/pnpm/pnpm/releases/download/v${version}/${file}`,
+  );
 }


### PR DESCRIPTION
Closes #195.

## Summary

pnpm v11 changed the release format from standalone executables to compressed archives (`.tar.gz` on Linux/macOS, `.zip` on Windows). This PR updates the action to handle both formats based on the major version.

- Add `src/archive.ts` with `extractArchive()` to unpack `.tar.gz` and `.zip` archives
- Update `getPnpmDownloadUrl()` in `src/pnpm.ts` to return a `URL` object, build the correct archive filename for v11+ and the legacy executable filename for v10 and below, and reject x64 macOS for v11+ (no binary provided by pnpm)
- Update `src/action.ts` to download either an archive or a direct binary and take the appropriate post-download step (extract + remove archive, or chmod)
- Re-enable the latest-pnpm setup step in CI that was blocked by #195, and update the pinned-version test from `9.15.5` to `10.34.0`