### PR TITLE
Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "typescript-eslint": "^8.60.1",
     "vitest": "^4.0.15"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "devEngines": {
     "runtime": {
       "name": "node",


### PR DESCRIPTION
This pull request resolves #246 by adding `"engines": { "node": ">=24" }` to `package.json` to complement the existing `use-node-version` in `.npmrc`.