### PR TITLE
Change action branding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: Setup Standalone pnpm
 author: Alfi Maulana
 description: Set up standalone pnpm with a specified version
 branding:
-  icon: chevrons-right
-  color: black
+  icon: package
+  color: orange
 inputs:
   version:
     description: The pnpm version to set up


### PR DESCRIPTION
This pull request resolves #248 by changing the action branding to use `package` icon with `orange` color.