### PR TITLE
Remove module option from tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
-    "module": "node16",
     "noEmit": true
   }
 }


### PR DESCRIPTION
The `module: node16` option was added to work around a Rollup issue, but Rollup has since been replaced by tsup (#245). tsup handles module resolution itself, so this option is no longer needed and `@tsconfig/node24` already provides the right defaults.