### PR TITLE
Show process output in log groups

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -13,15 +13,23 @@ function logError(err, options) {
   const params = "";
   process.stdout.write(`::error${params}::${message}${EOL}`);
 }
+function logCommand(command, ...args) {
+  const message = [command, ...args].join(" ");
+  process.stdout.write(`[command]${message}${EOL}`);
+}
+function beginLogGroup(name) {
+  process.stdout.write(`::group::${name}${EOL}`);
+}
+function endLogGroup() {
+  process.stdout.write(`::endgroup::${EOL}`);
+}
 function exec(command, args, opts) {
   return new Promise((resolve, reject) => {
-    const stdoutMode = opts?.stdout ?? "inherit";
-    const stderrMode = opts?.stderr ?? "inherit";
     const proc = spawn(command, args, {
       stdio: [
         "inherit",
-        stdoutMode === "inherit" ? "inherit" : stdoutMode === "capture" ? "pipe" : "ignore",
-        stderrMode === "inherit" ? "inherit" : stderrMode === "capture" ? "pipe" : "ignore"
+        "inherit" ,
+        "inherit" 
       ]
     });
     const stdoutChunks = [];
@@ -35,16 +43,7 @@ function exec(command, args, opts) {
     proc.on("error", reject);
     proc.on("close", (code) => {
       if (code === 0) {
-        if (stdoutMode === "capture" || stderrMode === "capture") {
-          const result = {};
-          if (stdoutMode === "capture") {
-            result.stdout = Buffer.concat(stdoutChunks).toString();
-          }
-          if (stderrMode === "capture") {
-            result.stderr = Buffer.concat(stderrChunks).toString();
-          }
-          resolve(result);
-        } else {
+        {
           resolve();
         }
       } else {
@@ -80,18 +79,18 @@ async function addPath(sysPath) {
 async function extractArchive(archiveFile, outputDir) {
   const ext = extname(archiveFile);
   switch (ext) {
-    case ".gz":
-      await exec("tar", ["-xzf", archiveFile, "-C", outputDir], {
-        stdout: "silent",
-        stderr: "silent"
-      });
+    case ".gz": {
+      const args = ["-xzvf", archiveFile, "-C", outputDir];
+      logCommand("tar", ...args);
+      await exec("tar", args);
       break;
-    case ".zip":
-      await exec("unzip", [archiveFile, "-d", outputDir], {
-        stdout: "silent",
-        stderr: "silent"
-      });
+    }
+    case ".zip": {
+      const args = [archiveFile, "-d", outputDir];
+      logCommand("unzip", ...args);
+      await exec("unzip", args);
       break;
+    }
     default:
       throw new Error(`Unsupported archive extension: ${ext}`);
   }
@@ -184,17 +183,24 @@ async function setupPnpmAction() {
     default:
       dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
   }
-  logInfo(`Download pnpm ${version}`);
-  await exec("curl", ["-fLSs", "--output", dlOut, dlUrl.href], {
-    stdout: "silent",
-    stderr: "silent"
-  });
+  beginLogGroup(`Download pnpm ${version}`);
+  try {
+    const args = ["-fL", "--output", dlOut, dlUrl.href];
+    logCommand("curl", ...args);
+    await exec("curl", args);
+  } finally {
+    endLogGroup();
+  }
   const dlOutExt = extname(dlOut);
   switch (dlOutExt) {
     case ".gz":
     case ".zip":
-      logInfo("Extract archive");
-      await extractArchive(dlOut, pnpmHome);
+      beginLogGroup("Extract archive");
+      try {
+        await extractArchive(dlOut, pnpmHome);
+      } finally {
+        endLogGroup();
+      }
       logInfo("Remove archive");
       await rm(dlOut);
       break;

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,5 +1,5 @@
 import { addPath, getInput, setEnv } from "ghakit/io";
-import { logInfo } from "ghakit/log";
+import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
 import { execFile } from "node:child_process";
 import { mkdir, rm } from "node:fs/promises";
@@ -20,6 +20,14 @@ import { setupPnpmAction } from "./action.js";
 import { resolvePnpmVersion } from "./pnpm.js";
 
 const execFileAsync = promisify(execFile);
+
+vi.mock(import("ghakit/exec"), async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    exec: (command, args) =>
+      original.exec(command, args, { stdout: "silent", stderr: "silent" }),
+  } as typeof original;
+});
 
 vi.mock(import("ghakit/io"));
 vi.mock(import("ghakit/log"));
@@ -56,6 +64,11 @@ describe("setupPnpmAction", () => {
   beforeEach(() => {
     logs = [];
     vi.mocked(logInfo).mockImplementation((message) => logs.push(message));
+    vi.mocked(logCommand).mockImplementation(() => logs.push("[command]"));
+    vi.mocked(beginLogGroup).mockImplementation((name) =>
+      logs.push(`[begin] ${name}`),
+    );
+    vi.mocked(endLogGroup).mockImplementation(() => logs.push("[end]"));
     vi.mocked(getRunnerToolCache).mockReturnValue(join(tmpDir, "cache"));
   });
 
@@ -68,8 +81,12 @@ describe("setupPnpmAction", () => {
     expect(logs).toStrictEqual([
       "Resolve pnpm version",
       "Create pnpm home",
-      `Download pnpm ${version}`,
-      "Extract archive",
+      `[begin] Download pnpm ${version}`,
+      "[command]",
+      "[end]",
+      "[begin] Extract archive",
+      "[command]",
+      "[end]",
       "Remove archive",
       "Add pnpm to PATH",
     ]);
@@ -92,7 +109,9 @@ describe("setupPnpmAction", () => {
     expect(logs).toStrictEqual([
       "Resolve pnpm version",
       "Create pnpm home",
-      `Download pnpm ${version}`,
+      `[begin] Download pnpm ${version}`,
+      "[command]",
+      "[end]",
       "Set file permissions",
       "Add pnpm to PATH",
     ]);

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,6 @@
 import { exec } from "ghakit/exec";
 import { addPath, getInput, setEnv } from "ghakit/io";
-import { logInfo } from "ghakit/log";
+import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
 import { chmod, mkdir, rm } from "node:fs/promises";
 import { arch, platform } from "node:os";
@@ -36,18 +36,25 @@ export async function setupPnpmAction() {
       dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
   }
 
-  logInfo(`Download pnpm ${version}`);
-  await exec("curl", ["-fLSs", "--output", dlOut, dlUrl.href], {
-    stdout: "silent",
-    stderr: "silent",
-  });
+  beginLogGroup(`Download pnpm ${version}`);
+  try {
+    const args: string[] = ["-fL", "--output", dlOut, dlUrl.href];
+    logCommand("curl", ...args);
+    await exec("curl", args);
+  } finally {
+    endLogGroup();
+  }
 
   const dlOutExt = extname(dlOut);
   switch (dlOutExt) {
     case ".gz":
     case ".zip":
-      logInfo("Extract archive");
-      await extractArchive(dlOut, pnpmHome);
+      beginLogGroup("Extract archive");
+      try {
+        await extractArchive(dlOut, pnpmHome);
+      } finally {
+        endLogGroup();
+      }
 
       logInfo("Remove archive");
       await rm(dlOut);

--- a/src/archive.test.ts
+++ b/src/archive.test.ts
@@ -1,12 +1,33 @@
+import { logCommand } from "ghakit/log";
 import { execFile } from "node:child_process";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { chdir } from "node:process";
 import { promisify } from "node:util";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { extractArchive } from "./archive.js";
 
 const execFileAsync = promisify(execFile);
+
+vi.mock(import("ghakit/exec"), async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    exec: (command, args) =>
+      original.exec(command, args, { stdout: "silent", stderr: "silent" }),
+  } as typeof original;
+});
+
+vi.mock(import("ghakit/log"));
+
+beforeEach(() => vi.clearAllMocks());
 
 const tmpDir = resolve(
   import.meta.dirname,
@@ -21,7 +42,7 @@ beforeAll(async () => {
 
 afterAll(() => rm(tmpDir, { force: true, recursive: true }));
 
-describe("extractArchive", { concurrent: true }, () => {
+describe("extractArchive", () => {
   test("extracts .tar.gz archive", { timeout: 60000 }, async () => {
     await mkdir(join(tmpDir, "tar", "foo"), { recursive: true });
     await writeFile(join(tmpDir, "tar", "foo", "bar"), "foo bar");
@@ -31,6 +52,8 @@ describe("extractArchive", { concurrent: true }, () => {
     await rm(join(tmpDir, "tar"), { force: true, recursive: true });
 
     await extractArchive(archiveFile, tmpDir);
+
+    expect(vi.mocked(logCommand)).toHaveBeenCalledOnce();
 
     const content = await readFile(join(tmpDir, "tar", "foo", "bar"), "utf-8");
     expect(content).toBe("foo bar");
@@ -46,6 +69,8 @@ describe("extractArchive", { concurrent: true }, () => {
 
     await extractArchive(archiveFile, tmpDir);
 
+    expect(vi.mocked(logCommand)).toHaveBeenCalledOnce();
+
     const content = await readFile(join(tmpDir, "zip", "foo", "bar"), "utf-8");
     expect(content).toBe("foo bar");
   });
@@ -56,5 +81,7 @@ describe("extractArchive", { concurrent: true }, () => {
     await expect(extractArchive("archive.7z", tmpDir)).rejects.toThrow(
       "Unsupported archive extension: .7z",
     );
+
+    expect(vi.mocked(logCommand)).not.toHaveBeenCalled();
   });
 });

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,22 +1,23 @@
 import { exec } from "ghakit/exec";
+import { logCommand } from "ghakit/log";
 import { extname } from "node:path";
 
 export async function extractArchive(archiveFile: string, outputDir: string) {
   const ext = extname(archiveFile);
   switch (ext) {
-    case ".gz":
-      await exec("tar", ["-xzf", archiveFile, "-C", outputDir], {
-        stdout: "silent",
-        stderr: "silent",
-      });
+    case ".gz": {
+      const args: string[] = ["-xzvf", archiveFile, "-C", outputDir];
+      logCommand("tar", ...args);
+      await exec("tar", args);
       break;
+    }
 
-    case ".zip":
-      await exec("unzip", [archiveFile, "-d", outputDir], {
-        stdout: "silent",
-        stderr: "silent",
-      });
+    case ".zip": {
+      const args: string[] = [archiveFile, "-d", outputDir];
+      logCommand("unzip", ...args);
+      await exec("unzip", args);
       break;
+    }
 
     default:
       throw new Error(`Unsupported archive extension: ${ext}`);


### PR DESCRIPTION
This pull request resolves #251 by updating the action to display the output of `curl`, `tar`, and `unzip` within dedicated log groups.

Grouping process output separately improves log readability while making it easier to inspect command execution details when troubleshooting.
