### PR TITLE
Skip pnpm setup when pnpm home is already populated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,15 @@ jobs:
           version="$(pnpm --version)"
           echo "$version"
           test "$version" = "10.34.0"
+
+      - name: Setup pnpm from cache
+        uses: ./setup-pnpm-action
+        env:
+          PATH: "" # forces cache usage by making curl unavailable
+
+      - name: Verify cached pnpm version
+        shell: bash
+        run: |
+          version="$(pnpm --version)"
+          echo "$version"
+          test "$version" != "10.34.0"

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,7 +1,7 @@
 import { arch, platform, EOL } from 'os';
 import { spawn } from 'child_process';
 import 'fs';
-import { mkdir, chmod, rm, appendFile } from 'fs/promises';
+import { access, mkdir, chmod, rm, appendFile } from 'fs/promises';
 import { join, extname, delimiter } from 'path';
 
 // node_modules/.pnpm/ghakit@1.0.0/node_modules/ghakit/dist/log.js
@@ -164,49 +164,54 @@ function getPnpmDownloadUrl({
 async function setupPnpmAction() {
   logInfo("Resolve pnpm version");
   const version = await resolvePnpmVersion(getInput("version").trim());
-  logInfo("Create pnpm home");
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
-  await mkdir(pnpmHome, { recursive: true });
-  const dlUrl = getPnpmDownloadUrl({
-    version,
-    platform: platform(),
-    arch: arch()
-  });
-  const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
-  let dlOut;
-  const dlFileExt = extname(dlFile);
-  switch (dlFileExt) {
-    case ".gz":
-    case ".zip":
-      dlOut = join(pnpmHome, dlFile);
-      break;
-    default:
-      dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
-  }
-  beginLogGroup(`Download pnpm ${version}`);
   try {
-    const args = ["-fL", "--output", dlOut, dlUrl.href];
-    logCommand("curl", ...args);
-    await exec("curl", args);
-  } finally {
-    endLogGroup();
-  }
-  const dlOutExt = extname(dlOut);
-  switch (dlOutExt) {
-    case ".gz":
-    case ".zip":
-      beginLogGroup("Extract archive");
-      try {
-        await extractArchive(dlOut, pnpmHome);
-      } finally {
-        endLogGroup();
-      }
-      logInfo("Remove archive");
-      await rm(dlOut);
-      break;
-    default:
-      logInfo("Set file permissions");
-      await chmod(dlOut, "755");
+    await access(pnpmHome);
+    logInfo(`Use cached pnpm ${version}`);
+  } catch {
+    logInfo("Create pnpm home");
+    await mkdir(pnpmHome, { recursive: true });
+    const dlUrl = getPnpmDownloadUrl({
+      version,
+      platform: platform(),
+      arch: arch()
+    });
+    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
+    let dlOut;
+    const dlFileExt = extname(dlFile);
+    switch (dlFileExt) {
+      case ".gz":
+      case ".zip":
+        dlOut = join(pnpmHome, dlFile);
+        break;
+      default:
+        dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
+    }
+    beginLogGroup(`Download pnpm ${version}`);
+    try {
+      const args = ["-fL", "--output", dlOut, dlUrl.href];
+      logCommand("curl", ...args);
+      await exec("curl", args);
+    } finally {
+      endLogGroup();
+    }
+    const dlOutExt = extname(dlOut);
+    switch (dlOutExt) {
+      case ".gz":
+      case ".zip":
+        beginLogGroup("Extract archive");
+        try {
+          await extractArchive(dlOut, pnpmHome);
+        } finally {
+          endLogGroup();
+        }
+        logInfo("Remove archive");
+        await rm(dlOut);
+        break;
+      default:
+        logInfo("Set file permissions");
+        await chmod(dlOut, "755");
+    }
   }
   logInfo("Add pnpm to PATH");
   await Promise.all([setEnv("PNPM_HOME", pnpmHome), addPath(pnpmHome)]);

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -72,7 +72,7 @@ describe("setupPnpmAction", () => {
     vi.mocked(getRunnerToolCache).mockReturnValue(join(tmpDir, "cache"));
   });
 
-  test("downloads latest version", { timeout: 60000 }, async () => {
+  test("sets up the latest version", { timeout: 60000 }, async () => {
     vi.mocked(getInput).mockReturnValue("latest");
     const version = await resolvePnpmVersion("latest");
 
@@ -100,7 +100,7 @@ describe("setupPnpmAction", () => {
     await assertPnpmVersion(version, pnpmHome);
   });
 
-  test("downloads specified version", { timeout: 60000 }, async () => {
+  test("sets up a specific version", { timeout: 60000 }, async () => {
     const version = "10.34.0";
     vi.mocked(getInput).mockReturnValue(version);
 
@@ -113,6 +113,27 @@ describe("setupPnpmAction", () => {
       "[command]",
       "[end]",
       "Set file permissions",
+      "Add pnpm to PATH",
+    ]);
+
+    const pnpmHome = join(tmpDir, "cache", "pnpm", version);
+    expect(vi.mocked(setEnv).mock.calls).toStrictEqual([
+      ["PNPM_HOME", pnpmHome],
+    ]);
+    expect(vi.mocked(addPath).mock.calls).toStrictEqual([[pnpmHome]]);
+
+    await assertPnpmVersion(version, pnpmHome);
+  });
+
+  test("sets up from cache", async () => {
+    vi.mocked(getInput).mockReturnValue("latest");
+    const version = await resolvePnpmVersion("latest");
+
+    await setupPnpmAction();
+
+    expect(logs).toStrictEqual([
+      "Resolve pnpm version",
+      `Use cached pnpm ${version}`,
       "Add pnpm to PATH",
     ]);
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,7 +2,7 @@ import { exec } from "ghakit/exec";
 import { addPath, getInput, setEnv } from "ghakit/io";
 import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
-import { chmod, mkdir, rm } from "node:fs/promises";
+import { access, chmod, mkdir, rm } from "node:fs/promises";
 import { arch, platform } from "node:os";
 import { extname, join } from "node:path";
 import { extractArchive } from "./archive.js";
@@ -12,57 +12,62 @@ export async function setupPnpmAction() {
   logInfo("Resolve pnpm version");
   const version = await resolvePnpmVersion(getInput("version").trim());
 
-  logInfo("Create pnpm home");
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
-  await mkdir(pnpmHome, { recursive: true });
-
-  const dlUrl = getPnpmDownloadUrl({
-    version,
-    platform: platform(),
-    arch: arch(),
-  });
-
-  const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
-
-  let dlOut: string;
-  const dlFileExt = extname(dlFile);
-  switch (dlFileExt) {
-    case ".gz":
-    case ".zip":
-      dlOut = join(pnpmHome, dlFile);
-      break;
-
-    default:
-      dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
-  }
-
-  beginLogGroup(`Download pnpm ${version}`);
   try {
-    const args: string[] = ["-fL", "--output", dlOut, dlUrl.href];
-    logCommand("curl", ...args);
-    await exec("curl", args);
-  } finally {
-    endLogGroup();
-  }
+    await access(pnpmHome);
+    logInfo(`Use cached pnpm ${version}`);
+  } catch {
+    logInfo("Create pnpm home");
+    await mkdir(pnpmHome, { recursive: true });
 
-  const dlOutExt = extname(dlOut);
-  switch (dlOutExt) {
-    case ".gz":
-    case ".zip":
-      beginLogGroup("Extract archive");
-      try {
-        await extractArchive(dlOut, pnpmHome);
-      } finally {
-        endLogGroup();
-      }
+    const dlUrl = getPnpmDownloadUrl({
+      version,
+      platform: platform(),
+      arch: arch(),
+    });
 
-      logInfo("Remove archive");
-      await rm(dlOut);
-      break;
+    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
 
-    default:
-      logInfo("Set file permissions");
-      await chmod(dlOut, "755");
+    let dlOut: string;
+    const dlFileExt = extname(dlFile);
+    switch (dlFileExt) {
+      case ".gz":
+      case ".zip":
+        dlOut = join(pnpmHome, dlFile);
+        break;
+
+      default:
+        dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
+    }
+
+    beginLogGroup(`Download pnpm ${version}`);
+    try {
+      const args: string[] = ["-fL", "--output", dlOut, dlUrl.href];
+      logCommand("curl", ...args);
+      await exec("curl", args);
+    } finally {
+      endLogGroup();
+    }
+
+    const dlOutExt = extname(dlOut);
+    switch (dlOutExt) {
+      case ".gz":
+      case ".zip":
+        beginLogGroup("Extract archive");
+        try {
+          await extractArchive(dlOut, pnpmHome);
+        } finally {
+          endLogGroup();
+        }
+
+        logInfo("Remove archive");
+        await rm(dlOut);
+        break;
+
+      default:
+        logInfo("Set file permissions");
+        await chmod(dlOut, "755");
+    }
   }
 
   logInfo("Add pnpm to PATH");


### PR DESCRIPTION
This pull request resolves #253 by updating pnpm setup to respect the GitHub Actions runner tool cache, avoiding redundant installation when pnpm is already available in the cache.