### PR TITLE
Update docs and action metadata to match setup-lefthook-action style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,32 +2,76 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
-
-```sh
-pnpm vitest run           # run all tests (Vitest)
-pnpm vitest run <file>    # run a single test file
-pnpm tsc                  # type check
-pnpm eslint .             # lint
-pnpm prettier --check .   # check formatting
-pnpm prettier --write .   # fix formatting
-pnpm tsup                 # build — outputs dist/main.js
-```
-
-Pre-commit hooks are managed by [Lefthook](https://lefthook.dev/). Hooks automatically run formatting, linting, type checking, and building before each commit.
-
-## Architecture
+## About This Repository
 
 This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm binary on all GitHub-hosted runner platforms (Linux x64/arm64, macOS x64/arm64, Windows x64/arm64).
 
-The entry point is `dist/main.js`, produced by tsup bundling `src/main.ts`. The `dist/` folder must be committed — CI verifies there is no git diff after building.
+## Architecture
 
-Source files in `src/`:
+### Source Files
 
-- `main.ts` — action entry point; calls `setupPnpmAction()` from `action.ts` and handles top-level errors by logging and setting `process.exitCode = 1`.
-- `action.ts` — `setupPnpmAction()` orchestrates the full setup: resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/` (via `ghakit/vars`), skips download if the directory already exists (cache hit), otherwise downloads the binary via `exec("curl", ...)` from `ghakit/exec`, extracts or chmods it to `755`, adds `PNPM_HOME` to `PATH`, and sets the `version` output.
-- `pnpm.ts` — `resolvePnpmVersionFromResponse(version, res)` (extracts the resolved version from an NPM registry HTTP response, throws on unknown version or HTTP error), `resolvePnpmVersion(version)` (fetches the `@pnpm/exe` NPM registry entry and delegates to `resolvePnpmVersionFromResponse`), `getPnpmBinaryName(platform)` (returns `"pnpm.exe"` on Windows, `"pnpm"` otherwise), `getPnpmDownloadUrl({version, platform, arch})` (builds the GitHub release download URL, throws on unsupported platform or arch).
+- **`src/main.ts`** — Entry point that calls the action function and handles error logging and exit codes.
+- **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached, extracts or sets permissions on it, adds it to `PATH`, and sets the `version` output.
+- **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry, and builds the download URL for a given version, platform, and arch.
+- **`src/archive.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`.
+- **`src/action.test.ts`** — Integration tests for the action with a mocked GitHub Actions environment and a real binary download.
+- **`src/archive.test.ts`** — Tests for `extractArchive` with real archive operations.
+- **`src/pnpm.test.ts`** — Tests for the pure functions in `pnpm.ts`, including live network calls.
 
-All packages — including runtime dependencies like `ghakit` — belong in `devDependencies`. tsup bundles everything into `dist/main.js`, so there are no runtime `dependencies` needed.
+### TypeScript Configuration
 
-Tests use Vitest and must maintain 100% coverage (enforced in `vitest.config.ts`). Test files are co-located with sources (`*.test.ts`). Most external dependencies (`ghakit`, `fs`, network) are mocked via `vi.mock()`. Note that `fetchPnpmVersionsRegistry()` makes a real network call in tests.
+- **`tsconfig.json`** — Type-check config with `noEmit: true`; used by `pnpm tsc`. Extends `@tsconfig/node24`, which sets `module: nodenext` and `moduleResolution: node16`. This requires import paths to use `.js` extensions even when importing `.ts` source files.
+
+### Build Configuration
+
+- **`tsup.config.ts`** — Configures tsup to bundle `src/main.ts` as ESM with tree-shaking enabled.
+
+### Build Output
+
+- **`dist/main.js`** — Single bundled ESM file. Must be committed — CI verifies there is no git diff after building.
+
+### Action Definition
+
+- **`action.yml`** — Declares one optional input (`version`), one output (`version` — the installed version), branding, and the Node.js runtime pointing to `dist/main.js`.
+
+## Tooling
+
+- **pnpm** is the package manager. `packageManager` in `package.json` pins the pnpm version; `devEngines.runtime` selects the Node.js version; `engines.node` asserts Node >=24.
+- **tsup** is the bundler. All packages — including runtime dependencies like `ghakit` — belong in `devDependencies`; tsup bundles everything so there are no runtime `dependencies` needed.
+- **ghakit** handles all GitHub Actions-specific concerns: reading inputs, writing outputs, logging, and spawning processes.
+- **ESLint** uses flat config (`eslint.config.ts`) with `@eslint/js` recommended rules and `typescript-eslint` strict + stylistic type-checked rules.
+- **Prettier** uses `prettier-plugin-organize-imports` — import order is auto-managed.
+- **Lefthook** manages Git hooks via `lefthook.yaml`. It is a standalone binary, not a pnpm package.
+- **Vitest** uses `vitest.config.ts` with coverage always enabled, text reporter, and 100% thresholds across all metrics.
+- **Dependabot** keeps GitHub Actions and npm dependencies up to date automatically via `.github/dependabot.yaml`.
+
+## Testing
+
+```sh
+pnpm vitest run             # Run all tests
+pnpm vitest run <file>      # Run a single test file
+```
+
+Coverage is always enabled and computed for all files imported during the test run. Running a single test file may fail the 100% threshold if it imports a source file that another test is responsible for fully covering — use the full suite for accurate results.
+
+## Checking and Fixing
+
+Use Lefthook to run the same steps as the pre-commit hook:
+
+```sh
+lefthook run pre-commit              # staged files only (default)
+lefthook run pre-commit --all-files  # all files — matches what CI runs
+```
+
+This installs dependencies, fixes formatting, fixes lint, type-checks, and builds the action — in that order, stopping on the first failure. If any file changes during the run, it also fails and shows a diff of what changed — re-stage the changed files and retry.
+
+Individual commands (manual fallback if needed): `pnpm prettier --write .`, `pnpm eslint --fix`, `pnpm tsc`, `pnpm tsup`.
+
+## CI
+
+CI has two jobs:
+
+- **Check** — runs `lefthook run pre-commit --all-files` (install, format, lint, type-check, build), then runs the full test suite with `pnpm vitest run`.
+- **Test** — checks out the action itself and runs it on `ubuntu-24.04`, `ubuntu-24.04-arm`, `ubuntu-22.04`, `ubuntu-22.04-arm`, `macos-15`, `macos-14`, `windows-2025`, and `windows-2022` to verify the actual action behavior end-to-end.
+
+See `.github/workflows/ci.yaml` for full details.

--- a/README.md
+++ b/README.md
@@ -1,46 +1,40 @@
 # Setup Standalone pnpm Action
 
-Set up standalone [pnpm](https://pnpm.io/) with a specified version in [GitHub Actions](https://github.com/features/actions).
+A GitHub Action that downloads and sets up standalone [pnpm](https://pnpm.io/) on the runner.
 
-This action installs the standalone version of pnpm from the [GitHub releases](https://github.com/pnpm/pnpm/releases) page, allowing pnpm to be used as both a package manager and a Node.js version manager (see [pnpm env](https://pnpm.io/cli/env)).
-
-## Available Inputs
-
-| Name      | Type                  | Description                                         |
-| --------- | --------------------- | --------------------------------------------------- |
-| `version` | Version number or tag | The pnpm version to install (defaults to `latest`). |
-
-## Available Outputs
-
-| Name      | Type           | Description                                  |
-| --------- | -------------- | -------------------------------------------- |
-| `version` | Version number | Resolved version of pnpm that was installed. |
-
-## Example Usage
-
-Here's a basic example of how to use this action to set up the latest version of standalone pnpm in a GitHub Actions workflow:
+## Usage
 
 ```yaml
-name: CI
-on:
-  push:
-jobs:
-  build:
-    name: Build Project
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout Project
-        uses: actions/checkout@v4.2.2
+- name: Setup pnpm
+  uses: threeal/setup-pnpm-action@v2.0.0
+```
 
-      - name: Setup pnpm
-        uses: threeal/setup-pnpm-action@v1.0.0
+## Inputs
 
-      - name: Check pnpm
-        run: pnpm --version
+| Name      | Description                     | Default        |
+| --------- | ------------------------------- | -------------- |
+| `version` | The version of pnpm to install. | Latest version |
+
+## Outputs
+
+| Name      | Description                             |
+| --------- | --------------------------------------- |
+| `version` | The version of pnpm that was installed. |
+
+## Example
+
+```yaml
+- name: Setup pnpm
+  uses: threeal/setup-pnpm-action@v2.0.0
+  with:
+    version: 11.5.0
+
+- name: Check pnpm
+  run: pnpm --version
 ```
 
 ## License
 
-This project is licensed under the terms of the [MIT License](./LICENSE).
+This project is licensed under the [MIT License](LICENSE).
 
 Copyright © 2025-2026 [Alfi Maulana](https://github.com/threeal)

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,17 @@
 name: Setup Standalone pnpm
 author: Alfi Maulana
-description: Set up standalone pnpm with a specified version
+description: Set up standalone pnpm on the runner
 branding:
   icon: package
   color: orange
 inputs:
   version:
-    description: The version or tag of pnpm to set up.
+    description: The version of pnpm to install. Defaults to the latest version.
+    required: false
     default: latest
 outputs:
   version:
-    description: Resolved version of pnpm that was installed.
+    description: The version of pnpm that was installed.
 runs:
   using: node24
   main: dist/main.js


### PR DESCRIPTION
## Summary

- Rewrites `CLAUDE.md` to match the structure used in `setup-lefthook-action`: adds an **About This Repository** section, expands **Architecture** into sub-sections (Source Files, TypeScript Configuration, Build Configuration, Build Output, Action Definition), and adds **Tooling**, **Testing**, **Checking and Fixing**, and **CI** sections.
- Rewrites `README.md` to match the concise style of `setup-lefthook-action`: drops the verbose description and full-job example in favor of a short intro, compact **Usage** snippet, and focused **Example** showing only the relevant steps.
- Updates `action.yml` descriptions to be uniform with the README and `setup-lefthook-action` conventions: action description, input description (with explicit `required: false`), and output description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)