### PR TITLE
Add version-file input to determine pnpm version from package.json

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup pnpm
         uses: ./
         with:
-          version: 11.5.1
+          version-file: package.json
 
       - name: Check pre-commit hook
         run: lefthook run pre-commit --all-files
@@ -54,7 +54,7 @@ jobs:
         if: matrix.os != 'macos-15-intel'
         uses: ./setup-pnpm-action
 
-      - name: Verify latest pnpm version
+      - name: Verify pnpm version
         if: matrix.os != 'macos-15-intel'
         shell: bash
         run: |
@@ -64,12 +64,12 @@ jobs:
           test "$version" = "${{ steps.setup-pnpm.outputs.version }}"
 
       - name: Setup pnpm with version input
-        id: setup-pnpm-versioned
+        id: setup-pnpm-version
         uses: ./setup-pnpm-action
         with:
           version: 10.34.0
 
-      - name: Verify specified pnpm version
+      - name: Verify pnpm version
         # TODO: pnpm v10 and below verification keeps failing on Windows arm64 runners
         if: matrix.os != 'windows-11-arm'
         shell: bash
@@ -77,7 +77,29 @@ jobs:
           version="$(pnpm --version)"
           echo "$version"
           test "$version" = "10.34.0"
-          test "$version" = "${{ steps.setup-pnpm-versioned.outputs.version }}"
+          test "$version" = "${{ steps.setup-pnpm-version.outputs.version }}"
+
+      - name: Write package.json
+        shell: bash
+        run: |
+          mkdir project
+          echo '{"packageManager":"pnpm@9.15.0"}' > project/package.json
+
+      - name: Setup pnpm with version-file input
+        id: setup-pnpm-version-file
+        uses: ./setup-pnpm-action
+        with:
+          version-file: project/package.json
+
+      - name: Verify pnpm version
+        # TODO: pnpm v10 and below verification keeps failing on Windows arm64 runners
+        if: matrix.os != 'windows-11-arm'
+        shell: bash
+        run: |
+          version="$(pnpm --version)"
+          echo "$version"
+          test "$version" = "9.15.0"
+          test "$version" = "${{ steps.setup-pnpm-version-file.outputs.version }}"
 
       - name: Setup pnpm from cache
         id: setup-pnpm-cached
@@ -86,7 +108,7 @@ jobs:
         env:
           PATH: "" # forces cache usage by making curl unavailable
 
-      - name: Verify cached pnpm version
+      - name: Verify pnpm version
         if: matrix.os != 'macos-15-intel'
         shell: bash
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,13 @@ This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm 
 
 - **`src/main.ts`** — Entry point that calls the action function and handles error logging and exit codes.
 - **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached, extracts or sets permissions on it, adds it to `PATH`, and sets the `version` output.
+- **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used.
 - **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry, and builds the download URL for a given version, platform, and arch.
 - **`src/archive.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`.
 - **`src/action.test.ts`** — Integration tests for the action with a mocked GitHub Actions environment and a real binary download.
-- **`src/archive.test.ts`** — Tests for `extractArchive` with real archive operations.
+- **`src/input.test.ts`** — Tests for `extractVersionFromPackageJson` and `getVersionInput` in `input.ts`.
 - **`src/pnpm.test.ts`** — Tests for the pure functions in `pnpm.ts`, including live network calls.
+- **`src/archive.test.ts`** — Tests for `extractArchive` with real archive operations.
 
 ### TypeScript Configuration
 
@@ -32,7 +34,7 @@ This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm 
 
 ### Action Definition
 
-- **`action.yml`** — Declares one optional input (`version`), one output (`version` — the installed version), branding, and the Node.js runtime pointing to `dist/main.js`.
+- **`action.yml`** — Declares two optional inputs (`version` and `version-file`), one output (`version` — the installed version), branding, and the Node.js runtime pointing to `dist/main.js`.
 
 ## Tooling
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ A GitHub Action that downloads and sets up standalone [pnpm](https://pnpm.io/) o
 
 ## Inputs
 
-| Name      | Description                     | Default        |
-| --------- | ------------------------------- | -------------- |
-| `version` | The version of pnpm to install. | Latest version |
+| Name           | Description                                                                                              |
+| -------------- | -------------------------------------------------------------------------------------------------------- |
+| `version`      | The version or tag of pnpm to install.                                                                   |
+| `version-file` | A file specifying the version of pnpm to install. Supports `package.json` with a `packageManager` field. |
+
+`version` and `version-file` are mutually exclusive. If neither is set, the latest version of pnpm will be installed.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,11 @@ branding:
   color: orange
 inputs:
   version:
-    description: The version of pnpm to install. Defaults to the latest version.
-    required: false
-    default: latest
+    description: The version or tag of pnpm to install.
+    default: ""
+  version-file:
+    description: A file specifying the version of pnpm to install. Supports package.json with a packageManager field.
+    default: ""
 outputs:
   version:
     description: The version of pnpm that was installed.

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,8 +1,8 @@
 import { arch, platform, EOL } from 'os';
 import { spawn } from 'child_process';
 import 'fs';
-import { access, mkdir, chmod, rm, appendFile } from 'fs/promises';
-import { join, extname, delimiter } from 'path';
+import { access, mkdir, chmod, rm, readFile, appendFile } from 'fs/promises';
+import { join, extname, basename, delimiter } from 'path';
 
 // node_modules/.pnpm/ghakit@1.0.0/node_modules/ghakit/dist/log.js
 function logInfo(message) {
@@ -101,6 +101,53 @@ async function extractArchive(archiveFile, outputDir) {
       throw new Error(`Unsupported archive extension: ${ext}`);
   }
 }
+function extractVersionFromPackageJson(packageJson) {
+  if (typeof packageJson !== "object" || packageJson === null) {
+    throw new Error("package.json must be an object");
+  }
+  if (!("packageManager" in packageJson)) {
+    throw new Error("Missing `packageManager` field in package.json");
+  }
+  if (typeof packageJson.packageManager !== "string") {
+    throw new Error("`packageManager` must be a string");
+  }
+  const match = /^([^@]+)@(\d+\.\d+\.\d+)(?:$|\+.*)$/.exec(
+    packageJson.packageManager
+  );
+  if (match?.length !== 3) {
+    throw new Error(
+      `Invalid \`packageManager\` value: ${packageJson.packageManager}`
+    );
+  }
+  if (match[1] !== "pnpm") {
+    throw new Error(`Unsupported package manager: ${match[1]}, expected pnpm`);
+  }
+  return match[2];
+}
+async function getVersionInput() {
+  const version = getInput("version").trim();
+  const versionFile = getInput("version-file").trim();
+  if (version !== "") {
+    if (versionFile !== "") {
+      throw new Error(
+        "Cannot specify both `version` and `version-file` inputs"
+      );
+    }
+    return version;
+  }
+  if (versionFile !== "") {
+    const versionFileName = basename(versionFile);
+    if (versionFileName === "package.json") {
+      logInfo("Read version from package.json");
+      const content = await readFile(versionFile, "utf-8");
+      return extractVersionFromPackageJson(JSON.parse(content));
+    } else {
+      throw new Error(`Unsupported version file: ${versionFileName}`);
+    }
+  }
+  logInfo("No version specified, use latest");
+  return "latest";
+}
 
 // src/pnpm.ts
 async function resolvePnpmVersionFromResponse(version, res) {
@@ -168,8 +215,9 @@ function getPnpmDownloadUrl({
 
 // src/action.ts
 async function setupPnpmAction() {
+  const versionInput = await getVersionInput();
   logInfo("Resolve pnpm version");
-  const version = await resolvePnpmVersion(getInput("version").trim());
+  const version = await resolvePnpmVersion(versionInput);
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
   await setEnv("PNPM_HOME", pnpmHome);
   try {

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,4 +1,4 @@
-import { addPath, getInput, setEnv, setOutput } from "ghakit/io";
+import { addPath, setEnv, setOutput } from "ghakit/io";
 import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
 import { execFile } from "node:child_process";
@@ -17,6 +17,7 @@ import {
   vi,
 } from "vitest";
 import { setupPnpmAction } from "./action.js";
+import { getVersionInput } from "./input.js";
 import { resolvePnpmVersion } from "./pnpm.js";
 
 const execFileAsync = promisify(execFile);
@@ -32,6 +33,7 @@ vi.mock(import("ghakit/exec"), async (importOriginal) => {
 vi.mock(import("ghakit/io"));
 vi.mock(import("ghakit/log"));
 vi.mock(import("ghakit/vars"));
+vi.mock(import("./input.js"));
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -73,7 +75,7 @@ describe("setupPnpmAction", () => {
   });
 
   test("sets up the latest version", { timeout: 60000 }, async () => {
-    vi.mocked(getInput).mockReturnValue("latest");
+    vi.mocked(getVersionInput).mockResolvedValue("latest");
     const version = await resolvePnpmVersion("latest");
 
     await setupPnpmAction();
@@ -105,7 +107,7 @@ describe("setupPnpmAction", () => {
 
   test("sets up a specific version", { timeout: 60000 }, async () => {
     const version = "10.34.0";
-    vi.mocked(getInput).mockReturnValue(version);
+    vi.mocked(getVersionInput).mockResolvedValue(version);
 
     await setupPnpmAction();
 
@@ -132,7 +134,7 @@ describe("setupPnpmAction", () => {
   });
 
   test("sets up from cache", async () => {
-    vi.mocked(getInput).mockReturnValue("latest");
+    vi.mocked(getVersionInput).mockResolvedValue("latest");
     const version = await resolvePnpmVersion("latest");
 
     await setupPnpmAction();

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,16 +1,19 @@
 import { exec } from "ghakit/exec";
-import { addPath, getInput, setEnv, setOutput } from "ghakit/io";
+import { addPath, setEnv, setOutput } from "ghakit/io";
 import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
 import { access, chmod, mkdir, rm } from "node:fs/promises";
 import { arch, platform } from "node:os";
 import { extname, join } from "node:path";
 import { extractArchive } from "./archive.js";
+import { getVersionInput } from "./input.js";
 import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
 
 export async function setupPnpmAction() {
+  const versionInput = await getVersionInput();
+
   logInfo("Resolve pnpm version");
-  const version = await resolvePnpmVersion(getInput("version").trim());
+  const version = await resolvePnpmVersion(versionInput);
 
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
   await setEnv("PNPM_HOME", pnpmHome);

--- a/src/input.test.ts
+++ b/src/input.test.ts
@@ -1,0 +1,141 @@
+import { getInput } from "ghakit/io";
+import { logInfo } from "ghakit/log";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { extractVersionFromPackageJson, getVersionInput } from "./input.js";
+
+vi.mock(import("ghakit/io"));
+vi.mock(import("ghakit/log"));
+
+beforeEach(() => vi.clearAllMocks());
+
+const tmpDir = resolve(
+  import.meta.dirname,
+  `.${basename(import.meta.filename)}.tmp`,
+);
+
+beforeAll(async () => {
+  await rm(tmpDir, { force: true, recursive: true });
+  await mkdir(tmpDir, { recursive: true });
+});
+
+afterAll(() => rm(tmpDir, { force: true, recursive: true }));
+
+describe("extractVersionFromPackageJson", () => {
+  test("returns the version", () => {
+    expect(
+      extractVersionFromPackageJson({ packageManager: "pnpm@11.5.0" }),
+    ).toBe("11.5.0");
+  });
+
+  test("returns the version when build metadata is present", () => {
+    expect(
+      extractVersionFromPackageJson({
+        packageManager: "pnpm@11.5.0+sha256.abc123",
+      }),
+    ).toBe("11.5.0");
+  });
+
+  test("throws when not an object", () => {
+    expect(() => extractVersionFromPackageJson("not an object")).toThrow(
+      "package.json must be an object",
+    );
+  });
+
+  test("throws when null", () => {
+    expect(() => extractVersionFromPackageJson(null)).toThrow(
+      "package.json must be an object",
+    );
+  });
+
+  test("throws when packageManager is missing", () => {
+    expect(() => extractVersionFromPackageJson({})).toThrow(
+      "Missing `packageManager` field in package.json",
+    );
+  });
+
+  test("throws when packageManager is not a string", () => {
+    expect(() =>
+      extractVersionFromPackageJson({ packageManager: 123 }),
+    ).toThrow("`packageManager` must be a string");
+  });
+
+  test("throws when packageManager has an invalid format", () => {
+    expect(() =>
+      extractVersionFromPackageJson({ packageManager: "invalid" }),
+    ).toThrow("Invalid `packageManager` value: invalid");
+  });
+
+  test("throws when the package manager is not pnpm", () => {
+    expect(() =>
+      extractVersionFromPackageJson({ packageManager: "npm@11.16.0" }),
+    ).toThrow("Unsupported package manager: npm, expected pnpm");
+  });
+});
+
+describe("getVersionInput", () => {
+  test("returns latest when no inputs are set", async () => {
+    vi.mocked(getInput).mockReturnValue("");
+    await expect(getVersionInput()).resolves.toBe("latest");
+    expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
+      ["No version specified, use latest"],
+    ]);
+  });
+
+  test("returns the version input", async () => {
+    vi.mocked(getInput).mockImplementation((name) =>
+      name === "version" ? "11.5.0" : "",
+    );
+    await expect(getVersionInput()).resolves.toBe("11.5.0");
+    expect(vi.mocked(logInfo).mock.calls).toStrictEqual([]);
+  });
+
+  test("reads version from package.json", async () => {
+    const packageJsonPath = join(tmpDir, "package.json");
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({ packageManager: "pnpm@11.5.0" }),
+    );
+    vi.mocked(getInput).mockImplementation((name) =>
+      name === "version-file" ? packageJsonPath : "",
+    );
+
+    await expect(getVersionInput()).resolves.toBe("11.5.0");
+    expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
+      ["Read version from package.json"],
+    ]);
+  });
+
+  test("throws when both version and version-file are set", async () => {
+    vi.mocked(getInput).mockImplementation((name) => {
+      switch (name) {
+        case "version":
+          return "11.5.0";
+        case "version-file":
+          return "package.json";
+      }
+      return "";
+    });
+    await expect(getVersionInput()).rejects.toThrow(
+      "Cannot specify both `version` and `version-file` inputs",
+    );
+  });
+
+  test("throws for unsupported version file", async () => {
+    vi.mocked(getInput).mockImplementation((name) =>
+      name === "version-file" ? join(tmpDir, ".npmrc") : "",
+    );
+    await expect(getVersionInput()).rejects.toThrow(
+      "Unsupported version file: .npmrc",
+    );
+  });
+});

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,61 @@
+import { getInput } from "ghakit/io";
+import { logInfo } from "ghakit/log";
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+export function extractVersionFromPackageJson(packageJson: unknown): string {
+  if (typeof packageJson !== "object" || packageJson === null) {
+    throw new Error("package.json must be an object");
+  }
+
+  if (!("packageManager" in packageJson)) {
+    throw new Error("Missing `packageManager` field in package.json");
+  }
+
+  if (typeof packageJson.packageManager !== "string") {
+    throw new Error("`packageManager` must be a string");
+  }
+
+  const match = /^([^@]+)@(\d+\.\d+\.\d+)(?:$|\+.*)$/.exec(
+    packageJson.packageManager,
+  );
+  if (match?.length !== 3) {
+    throw new Error(
+      `Invalid \`packageManager\` value: ${packageJson.packageManager}`,
+    );
+  }
+
+  if (match[1] !== "pnpm") {
+    throw new Error(`Unsupported package manager: ${match[1]}, expected pnpm`);
+  }
+
+  return match[2];
+}
+
+export async function getVersionInput(): Promise<string> {
+  const version = getInput("version").trim();
+  const versionFile = getInput("version-file").trim();
+
+  if (version !== "") {
+    if (versionFile !== "") {
+      throw new Error(
+        "Cannot specify both `version` and `version-file` inputs",
+      );
+    }
+    return version;
+  }
+
+  if (versionFile !== "") {
+    const versionFileName = basename(versionFile);
+    if (versionFileName === "package.json") {
+      logInfo("Read version from package.json");
+      const content = await readFile(versionFile, "utf-8");
+      return extractVersionFromPackageJson(JSON.parse(content));
+    } else {
+      throw new Error(`Unsupported version file: ${versionFileName}`);
+    }
+  }
+
+  logInfo("No version specified, use latest");
+  return "latest";
+}


### PR DESCRIPTION
Resolves #259.

## Summary

- Adds a new `version-file` input that reads the pnpm version to install from a file's `packageManager` field
- Supports `package.json` files with a `packageManager: "pnpm@x.y.z"` field
- `version` and `version-file` are mutually exclusive — specifying both throws an error
- If neither input is set, the action falls back to installing the latest version
- Extracts input resolution into a new `src/input.ts` module with full test coverage
- Updates CI to also test the `version-file` input end-to-end across all runner platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)