### PR TITLE
Read pnpm version from package.json by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup pnpm
         uses: ./
-        with:
-          version-file: package.json
 
       - name: Check pre-commit hook
         run: lefthook run pre-commit --all-files
@@ -79,6 +77,22 @@ jobs:
           test "$version" = "10.34.0"
           test "$version" = "${{ steps.setup-pnpm-version.outputs.version }}"
 
+      - name: Setup pnpm from cache
+        id: setup-pnpm-cached
+        if: matrix.os != 'macos-15-intel'
+        uses: ./setup-pnpm-action
+        env:
+          PATH: "" # forces cache usage by making curl unavailable
+
+      - name: Verify pnpm version
+        if: matrix.os != 'macos-15-intel'
+        shell: bash
+        run: |
+          version="$(pnpm --version)"
+          echo "$version"
+          test "$version" != "10.34.0"
+          test "$version" = "${{ steps.setup-pnpm-cached.outputs.version }}"
+
       - name: Write package.json
         shell: bash
         run: |
@@ -96,23 +110,29 @@ jobs:
         if: matrix.os != 'windows-11-arm'
         shell: bash
         run: |
+          rm -rf project
           version="$(pnpm --version)"
           echo "$version"
           test "$version" = "9.15.0"
           test "$version" = "${{ steps.setup-pnpm-version-file.outputs.version }}"
 
-      - name: Setup pnpm from cache
-        id: setup-pnpm-cached
-        if: matrix.os != 'macos-15-intel'
+      - name: Write package.json
+        shell: bash
+        run: echo '{"packageManager":"pnpm@9.15.0"}' > package.json
+
+      - name: Setup pnpm from cache with package.json
+        id: setup-pnpm-cached-package-json
         uses: ./setup-pnpm-action
         env:
           PATH: "" # forces cache usage by making curl unavailable
 
       - name: Verify pnpm version
-        if: matrix.os != 'macos-15-intel'
+        # TODO: pnpm v10 and below verification keeps failing on Windows arm64 runners
+        if: matrix.os != 'windows-11-arm'
         shell: bash
         run: |
+          rm package.json
           version="$(pnpm --version)"
           echo "$version"
-          test "$version" != "10.34.0"
-          test "$version" = "${{ steps.setup-pnpm-cached.outputs.version }}"
+          test "$version" = "9.15.0"
+          test "$version" = "${{ steps.setup-pnpm-cached-package-json.outputs.version }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm 
 
 - **`src/main.ts`** — Entry point that calls the action function and handles error logging and exit codes.
 - **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached, extracts or sets permissions on it, adds it to `PATH`, and sets the `version` output.
-- **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used.
+- **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used or when neither input is set and a `package.json` exists in the current directory.
 - **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry, and builds the download URL for a given version, platform, and arch.
 - **`src/archive.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`.
 - **`src/action.test.ts`** — Integration tests for the action with a mocked GitHub Actions environment and a real binary download.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A GitHub Action that downloads and sets up standalone [pnpm](https://pnpm.io/) o
 | `version`      | The version or tag of pnpm to install.                                                                   |
 | `version-file` | A file specifying the version of pnpm to install. Supports `package.json` with a `packageManager` field. |
 
-`version` and `version-file` are mutually exclusive. If neither is set, the latest version of pnpm will be installed.
+`version` and `version-file` are mutually exclusive. If neither is set, the version is read from `package.json` in the current directory if available, otherwise the latest version is installed.
 
 ## Outputs
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -145,8 +145,20 @@ async function getVersionInput() {
       throw new Error(`Unsupported version file: ${versionFileName}`);
     }
   }
-  logInfo("No version specified, use latest");
-  return "latest";
+  try {
+    const content = await readFile("package.json", "utf-8");
+    logInfo("No version specified, read version from package.json");
+    try {
+      return extractVersionFromPackageJson(JSON.parse(content));
+    } catch (err) {
+      logError(err);
+      logInfo("Failed to read version from package.json, use latest");
+      return "latest";
+    }
+  } catch {
+    logInfo("No version specified, use latest");
+    return "latest";
+  }
 }
 
 // src/pnpm.ts

--- a/src/input.test.ts
+++ b/src/input.test.ts
@@ -1,7 +1,8 @@
 import { getInput } from "ghakit/io";
-import { logInfo } from "ghakit/log";
+import { logError, logInfo } from "ghakit/log";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
+import { chdir } from "node:process";
 import {
   afterAll,
   beforeAll,
@@ -26,6 +27,7 @@ const tmpDir = resolve(
 beforeAll(async () => {
   await rm(tmpDir, { force: true, recursive: true });
   await mkdir(tmpDir, { recursive: true });
+  chdir(tmpDir);
 });
 
 afterAll(() => rm(tmpDir, { force: true, recursive: true }));
@@ -83,24 +85,54 @@ describe("extractVersionFromPackageJson", () => {
 });
 
 describe("getVersionInput", () => {
+  beforeEach(() => rm("package.json", { force: true }));
+
   test("returns latest when no inputs are set", async () => {
     vi.mocked(getInput).mockReturnValue("");
+
     await expect(getVersionInput()).resolves.toBe("latest");
     expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
       ["No version specified, use latest"],
     ]);
   });
 
+  test("reads version from package.json when no inputs are set", async () => {
+    await writeFile(
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@11.5.0" }),
+    );
+    vi.mocked(getInput).mockReturnValue("");
+
+    await expect(getVersionInput()).resolves.toBe("11.5.0");
+    expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
+      ["No version specified, read version from package.json"],
+    ]);
+  });
+
+  test("returns latest when package.json is invalid and no inputs are set", async () => {
+    await writeFile("package.json", "{}");
+    vi.mocked(getInput).mockReturnValue("");
+
+    await expect(getVersionInput()).resolves.toBe("latest");
+    expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
+      ["No version specified, read version from package.json"],
+      ["Failed to read version from package.json, use latest"],
+    ]);
+    expect(logError).toHaveBeenCalledOnce();
+  });
+
   test("returns the version input", async () => {
     vi.mocked(getInput).mockImplementation((name) =>
       name === "version" ? "11.5.0" : "",
     );
+
     await expect(getVersionInput()).resolves.toBe("11.5.0");
     expect(vi.mocked(logInfo).mock.calls).toStrictEqual([]);
   });
 
   test("reads version from package.json", async () => {
-    const packageJsonPath = join(tmpDir, "package.json");
+    await mkdir("package", { recursive: true });
+    const packageJsonPath = join("package", "package.json");
     await writeFile(
       packageJsonPath,
       JSON.stringify({ packageManager: "pnpm@11.5.0" }),
@@ -125,6 +157,7 @@ describe("getVersionInput", () => {
       }
       return "";
     });
+
     await expect(getVersionInput()).rejects.toThrow(
       "Cannot specify both `version` and `version-file` inputs",
     );
@@ -132,8 +165,9 @@ describe("getVersionInput", () => {
 
   test("throws for unsupported version file", async () => {
     vi.mocked(getInput).mockImplementation((name) =>
-      name === "version-file" ? join(tmpDir, ".npmrc") : "",
+      name === "version-file" ? ".npmrc" : "",
     );
+
     await expect(getVersionInput()).rejects.toThrow(
       "Unsupported version file: .npmrc",
     );

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,5 +1,5 @@
 import { getInput } from "ghakit/io";
-import { logInfo } from "ghakit/log";
+import { logError, logInfo } from "ghakit/log";
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 
@@ -56,6 +56,18 @@ export async function getVersionInput(): Promise<string> {
     }
   }
 
-  logInfo("No version specified, use latest");
-  return "latest";
+  try {
+    const content = await readFile("package.json", "utf-8");
+    logInfo("No version specified, read version from package.json");
+    try {
+      return extractVersionFromPackageJson(JSON.parse(content));
+    } catch (err) {
+      logError(err);
+      logInfo("Failed to read version from package.json, use latest");
+      return "latest";
+    }
+  } catch {
+    logInfo("No version specified, use latest");
+    return "latest";
+  }
 }


### PR DESCRIPTION
Resolves #261.

## Summary

- When neither `version` nor `version-file` is set, the action now reads the pnpm version from `package.json` in the current working directory if one exists and contains a valid `packageManager` field. If the file is absent or the field is invalid, it falls back to installing the latest version.
- Updates CI to cover the new fallback behavior, including a cache-hit test after the version input test and a cache-hit test that exercises the `package.json` fallback.