### PR TITLE
Skip chmod for the pnpm executable on Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,11 @@ This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm 
 - **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached, extracts or sets permissions on it, adds it to `PATH`, and sets the `version` output.
 - **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used or when neither input is set and a `package.json` exists in the current directory.
 - **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry, and builds the download URL for a given version, platform, and arch.
-- **`src/archive.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`.
+- **`src/install.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`; `makeExecutable(file)` sets executable permissions on the file, or skips if the file has a `.exe` extension.
 - **`src/action.test.ts`** — Integration tests for the action with a mocked GitHub Actions environment and a real binary download.
 - **`src/input.test.ts`** — Tests for `extractVersionFromPackageJson` and `getVersionInput` in `input.ts`.
 - **`src/pnpm.test.ts`** — Tests for the pure functions in `pnpm.ts`, including live network calls.
-- **`src/archive.test.ts`** — Tests for `extractArchive` with real archive operations.
+- **`src/install.test.ts`** — Tests for `extractArchive` and `makeExecutable` in `install.ts`.
 
 ### TypeScript Configuration
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,7 +1,7 @@
 import { arch, platform, EOL } from 'os';
 import { spawn } from 'child_process';
 import 'fs';
-import { access, mkdir, chmod, rm, readFile, appendFile } from 'fs/promises';
+import { access, mkdir, rm, readFile, appendFile, chmod } from 'fs/promises';
 import { join, extname, basename, delimiter } from 'path';
 
 // node_modules/.pnpm/ghakit@1.0.0/node_modules/ghakit/dist/log.js
@@ -82,25 +82,6 @@ async function addPath(sysPath) {
   process.env.PATH = process.env.PATH !== void 0 ? `${sysPath}${delimiter}${process.env.PATH}` : sysPath;
   await appendFile(getGitHubPath(), `${sysPath}${EOL}`);
 }
-async function extractArchive(archiveFile, outputDir) {
-  const ext = extname(archiveFile);
-  switch (ext) {
-    case ".gz": {
-      const args = ["-xzvf", archiveFile, "-C", outputDir];
-      logCommand("tar", ...args);
-      await exec("tar", args);
-      break;
-    }
-    case ".zip": {
-      const args = [archiveFile, "-d", outputDir];
-      logCommand("unzip", ...args);
-      await exec("unzip", args);
-      break;
-    }
-    default:
-      throw new Error(`Unsupported archive extension: ${ext}`);
-  }
-}
 function extractVersionFromPackageJson(packageJson) {
   if (typeof packageJson !== "object" || packageJson === null) {
     throw new Error("package.json must be an object");
@@ -159,6 +140,30 @@ async function getVersionInput() {
     logInfo("No version specified, use latest");
     return "latest";
   }
+}
+async function extractArchive(archiveFile, outputDir) {
+  const ext = extname(archiveFile);
+  switch (ext) {
+    case ".gz": {
+      const args = ["-xzvf", archiveFile, "-C", outputDir];
+      logCommand("tar", ...args);
+      await exec("tar", args);
+      break;
+    }
+    case ".zip": {
+      const args = [archiveFile, "-d", outputDir];
+      logCommand("unzip", ...args);
+      await exec("unzip", args);
+      break;
+    }
+    default:
+      throw new Error(`Unsupported archive extension: ${ext}`);
+  }
+}
+async function makeExecutable(file) {
+  if (extname(file) === ".exe") return;
+  logInfo("Set file permissions");
+  await chmod(file, "755");
 }
 
 // src/pnpm.ts
@@ -276,8 +281,7 @@ async function setupPnpmAction() {
         await rm(dlOut);
         break;
       default:
-        logInfo("Set file permissions");
-        await chmod(dlOut, "755");
+        await makeExecutable(dlOut);
     }
   }
   logInfo("Add pnpm to PATH");

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,11 +2,11 @@ import { exec } from "ghakit/exec";
 import { addPath, setEnv, setOutput } from "ghakit/io";
 import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
-import { access, chmod, mkdir, rm } from "node:fs/promises";
+import { access, mkdir, rm } from "node:fs/promises";
 import { arch, platform } from "node:os";
 import { extname, join } from "node:path";
-import { extractArchive } from "./archive.js";
 import { getVersionInput } from "./input.js";
+import { extractArchive, makeExecutable } from "./install.js";
 import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
 
 export async function setupPnpmAction() {
@@ -70,8 +70,7 @@ export async function setupPnpmAction() {
         break;
 
       default:
-        logInfo("Set file permissions");
-        await chmod(dlOut, "755");
+        await makeExecutable(dlOut);
     }
   }
 

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -1,6 +1,6 @@
-import { logCommand } from "ghakit/log";
+import { logCommand, logInfo } from "ghakit/log";
 import { execFile } from "node:child_process";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { chdir } from "node:process";
 import { promisify } from "node:util";
@@ -13,7 +13,7 @@ import {
   test,
   vi,
 } from "vitest";
-import { extractArchive } from "./archive.js";
+import { extractArchive, makeExecutable } from "./install.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -47,13 +47,13 @@ describe("extractArchive", () => {
     await mkdir(join(tmpDir, "tar", "foo"), { recursive: true });
     await writeFile(join(tmpDir, "tar", "foo", "bar"), "foo bar");
 
-    const archiveFile = join(tmpDir, "archive.tar.gz");
-    await execFileAsync("tar", ["-czf", archiveFile, "-C", tmpDir, "tar"]);
+    const file = join(tmpDir, "archive.tar.gz");
+    await execFileAsync("tar", ["-czf", file, "-C", tmpDir, "tar"]);
     await rm(join(tmpDir, "tar"), { force: true, recursive: true });
 
-    await extractArchive(archiveFile, tmpDir);
+    await extractArchive(file, tmpDir);
 
-    expect(vi.mocked(logCommand)).toHaveBeenCalledOnce();
+    expect(logCommand).toHaveBeenCalledOnce();
 
     const content = await readFile(join(tmpDir, "tar", "foo", "bar"), "utf-8");
     expect(content).toBe("foo bar");
@@ -63,13 +63,13 @@ describe("extractArchive", () => {
     await mkdir(join(tmpDir, "zip", "foo"), { recursive: true });
     await writeFile(join(tmpDir, "zip", "foo", "bar"), "foo bar");
 
-    const archiveFile = join(tmpDir, "archive.zip");
-    await execFileAsync("zip", ["-r", archiveFile, "zip"], { cwd: tmpDir });
+    const file = join(tmpDir, "archive.zip");
+    await execFileAsync("zip", ["-r", file, "zip"], { cwd: tmpDir });
     await rm(join(tmpDir, "zip"), { force: true, recursive: true });
 
-    await extractArchive(archiveFile, tmpDir);
+    await extractArchive(file, tmpDir);
 
-    expect(vi.mocked(logCommand)).toHaveBeenCalledOnce();
+    expect(logCommand).toHaveBeenCalledOnce();
 
     const content = await readFile(join(tmpDir, "zip", "foo", "bar"), "utf-8");
     expect(content).toBe("foo bar");
@@ -82,6 +82,31 @@ describe("extractArchive", () => {
       "Unsupported archive extension: .7z",
     );
 
-    expect(vi.mocked(logCommand)).not.toHaveBeenCalled();
+    expect(logCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe("makeExecutable", () => {
+  test("sets file permissions for files without extension", async () => {
+    const file = join(tmpDir, "pnpm");
+    await writeFile(file, "");
+
+    await makeExecutable(file);
+
+    expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
+      ["Set file permissions"],
+    ]);
+
+    const { mode } = await stat(file);
+    expect(mode & 0o111).toBeGreaterThan(0);
+  });
+
+  test("skips setting file permissions for .exe files", async () => {
+    const file = join(tmpDir, "pnpm.exe");
+    await writeFile(file, "");
+
+    await makeExecutable(file);
+
+    expect(logInfo).not.toHaveBeenCalled();
   });
 });

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,5 +1,6 @@
 import { exec } from "ghakit/exec";
-import { logCommand } from "ghakit/log";
+import { logCommand, logInfo } from "ghakit/log";
+import { chmod } from "node:fs/promises";
 import { extname } from "node:path";
 
 export async function extractArchive(archiveFile: string, outputDir: string) {
@@ -22,4 +23,10 @@ export async function extractArchive(archiveFile: string, outputDir: string) {
     default:
       throw new Error(`Unsupported archive extension: ${ext}`);
   }
+}
+
+export async function makeExecutable(file: string) {
+  if (extname(file) === ".exe") return;
+  logInfo("Set file permissions");
+  await chmod(file, "755");
 }


### PR DESCRIPTION
Closes #265.

## Summary

- Moves `extractArchive` and a new `makeExecutable` function into `src/install.ts`, replacing `src/archive.ts`.
- `makeExecutable` sets executable permissions (`chmod 755`) on the downloaded binary, but skips the step entirely when the file has a `.exe` extension (Windows), where execute permission is determined by the file extension rather than mode bits.
- `src/action.ts` now delegates to `makeExecutable` instead of calling `chmod` directly, keeping it free of OS-specific permission logic.