### PR TITLE
Validate platform and architecture before version resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,11 @@ This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm 
 
 - **`src/main.ts`** — Entry point that calls the action function and handles error logging and exit codes.
 - **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached, extracts or sets permissions on it, adds it to `PATH`, and sets the `version` output.
-- **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used or when neither input is set and a `package.json` exists in the current directory.
+- **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used or when neither input is set and a `package.json` exists in the current directory. Also exports `getPlatform()` and `getArch()`, which validate and return the current `Platform` (`linux | darwin | win32`) and `Arch` (`x64 | arm64`) from `node:os`, throwing on unsupported values.
 - **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry, and builds the download URL for a given version, platform, and arch.
 - **`src/install.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`; `makeExecutable(file)` sets executable permissions on the file, or skips if the file has a `.exe` extension.
 - **`src/action.test.ts`** — Integration tests for the action with a mocked GitHub Actions environment and a real binary download.
-- **`src/input.test.ts`** — Tests for `extractVersionFromPackageJson` and `getVersionInput` in `input.ts`.
+- **`src/input.test.ts`** — Tests for `getPlatform`, `getArch`, `extractVersionFromPackageJson`, and `getVersionInput` in `input.ts`.
 - **`src/pnpm.test.ts`** — Tests for the pure functions in `pnpm.ts`, including live network calls.
 - **`src/install.test.ts`** — Tests for `extractArchive` and `makeExecutable` in `install.ts`.
 

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,4 +1,4 @@
-import { arch, platform, EOL } from 'os';
+import { EOL, platform, arch } from 'os';
 import { spawn } from 'child_process';
 import 'fs';
 import { access, mkdir, rm, readFile, appendFile, chmod } from 'fs/promises';
@@ -81,6 +81,27 @@ async function setEnv(name, value) {
 async function addPath(sysPath) {
   process.env.PATH = process.env.PATH !== void 0 ? `${sysPath}${delimiter}${process.env.PATH}` : sysPath;
   await appendFile(getGitHubPath(), `${sysPath}${EOL}`);
+}
+function getPlatform() {
+  const val = platform();
+  switch (val) {
+    case "linux":
+    case "darwin":
+    case "win32":
+      return val;
+    default:
+      throw new Error(`Unsupported platform: ${val}`);
+  }
+}
+function getArch() {
+  const val = arch();
+  switch (val) {
+    case "x64":
+    case "arm64":
+      return val;
+    default:
+      throw new Error(`Unsupported arch: ${val}`);
+  }
 }
 function extractVersionFromPackageJson(packageJson) {
   if (typeof packageJson !== "object" || packageJson === null) {
@@ -197,41 +218,37 @@ function getPnpmDownloadUrl({
   const match = /^(\d+)/.exec(version);
   if (!match) throw new Error(`Invalid version: ${version}`);
   const major = parseInt(match[1], 10);
-  let os;
-  switch (platform2) {
-    case "linux":
-      os = "linux";
-      break;
-    case "darwin":
-      os = "macos";
-      break;
-    case "win32":
-      os = "win";
-      break;
-    default:
-      throw new Error(`Unsupported platform: ${platform2}`);
+  const baseUrl = `https://github.com/pnpm/pnpm/releases/download/v${version}`;
+  if (major >= 11) {
+    if (platform2 === "darwin" && arch2 === "x64") {
+      throw new Error(
+        "pnpm does not provide x64 macOS binaries for version 11 and above"
+      );
+    }
+    const ext = platform2 == "win32" ? ".zip" : ".tar.gz";
+    return new URL(`${baseUrl}/pnpm-${platform2}-${arch2}${ext}`);
+  } else {
+    let os;
+    switch (platform2) {
+      case "linux":
+        os = "linux";
+        break;
+      case "darwin":
+        os = "macos";
+        break;
+      case "win32":
+        os = "win";
+        break;
+    }
+    const ext = platform2 === "win32" ? ".exe" : "";
+    return new URL(`${baseUrl}/pnpm-${os}-${arch2}${ext}`);
   }
-  switch (arch2) {
-    case "x64":
-      if (platform2 === "darwin" && major >= 11) {
-        throw new Error(
-          "pnpm does not provide x64 macOS binaries for version 11 and above"
-        );
-      }
-      break;
-    case "arm64":
-      break;
-    default:
-      throw new Error(`Unsupported arch: ${arch2}`);
-  }
-  const file = major >= 11 ? `pnpm-${platform2}-${arch2}${platform2 == "win32" ? ".zip" : ".tar.gz"}` : `pnpm-${os}-${arch2}${platform2 === "win32" ? ".exe" : ""}`;
-  return new URL(
-    `https://github.com/pnpm/pnpm/releases/download/v${version}/${file}`
-  );
 }
 
 // src/action.ts
 async function setupPnpmAction() {
+  const platform2 = getPlatform();
+  const arch2 = getArch();
   const versionInput = await getVersionInput();
   logInfo("Resolve pnpm version");
   const version = await resolvePnpmVersion(versionInput);
@@ -241,14 +258,10 @@ async function setupPnpmAction() {
     await access(pnpmHome);
     logInfo(`Use cached pnpm ${version}`);
   } catch {
+    const dlUrl = getPnpmDownloadUrl({ version, platform: platform2, arch: arch2 });
+    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
     logInfo("Create pnpm home");
     await mkdir(pnpmHome, { recursive: true });
-    const dlUrl = getPnpmDownloadUrl({
-      version,
-      platform: platform(),
-      arch: arch()
-    });
-    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
     let dlOut;
     const dlFileExt = extname(dlFile);
     switch (dlFileExt) {

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -33,7 +33,10 @@ vi.mock(import("ghakit/exec"), async (importOriginal) => {
 vi.mock(import("ghakit/io"));
 vi.mock(import("ghakit/log"));
 vi.mock(import("ghakit/vars"));
-vi.mock(import("./input.js"));
+vi.mock(import("./input.js"), async (importOriginal) => ({
+  ...(await importOriginal()),
+  getVersionInput: vi.fn(),
+}));
 
 beforeEach(() => vi.clearAllMocks());
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -3,13 +3,15 @@ import { addPath, setEnv, setOutput } from "ghakit/io";
 import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
 import { access, mkdir, rm } from "node:fs/promises";
-import { arch, platform } from "node:os";
 import { extname, join } from "node:path";
-import { getVersionInput } from "./input.js";
+import { getArch, getPlatform, getVersionInput } from "./input.js";
 import { extractArchive, makeExecutable } from "./install.js";
 import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
 
 export async function setupPnpmAction() {
+  const platform = getPlatform();
+  const arch = getArch();
+
   const versionInput = await getVersionInput();
 
   logInfo("Resolve pnpm version");
@@ -22,16 +24,11 @@ export async function setupPnpmAction() {
     await access(pnpmHome);
     logInfo(`Use cached pnpm ${version}`);
   } catch {
+    const dlUrl = getPnpmDownloadUrl({ version, platform, arch });
+    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
+
     logInfo("Create pnpm home");
     await mkdir(pnpmHome, { recursive: true });
-
-    const dlUrl = getPnpmDownloadUrl({
-      version,
-      platform: platform(),
-      arch: arch(),
-    });
-
-    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
 
     let dlOut: string;
     const dlFileExt = extname(dlFile);

--- a/src/input.test.ts
+++ b/src/input.test.ts
@@ -1,6 +1,7 @@
 import { getInput } from "ghakit/io";
 import { logError, logInfo } from "ghakit/log";
 import { mkdir, rm, writeFile } from "node:fs/promises";
+import { arch, platform } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { chdir } from "node:process";
 import {
@@ -12,10 +13,22 @@ import {
   test,
   vi,
 } from "vitest";
-import { extractVersionFromPackageJson, getVersionInput } from "./input.js";
+import {
+  Arch,
+  extractVersionFromPackageJson,
+  getArch,
+  getPlatform,
+  getVersionInput,
+  Platform,
+} from "./input.js";
 
 vi.mock(import("ghakit/io"));
 vi.mock(import("ghakit/log"));
+vi.mock(import("node:os"), async (importOriginal) => ({
+  ...(await importOriginal()),
+  arch: vi.fn(),
+  platform: vi.fn(),
+}));
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -31,6 +44,38 @@ beforeAll(async () => {
 });
 
 afterAll(() => rm(tmpDir, { force: true, recursive: true }));
+
+describe("getPlatform", () => {
+  const platforms: { val: Platform }[] = [
+    { val: "linux" },
+    { val: "darwin" },
+    { val: "win32" },
+  ];
+
+  test.each(platforms)("returns $val", ({ val }) => {
+    vi.mocked(platform).mockReturnValue(val);
+    expect(getPlatform()).toBe(val);
+  });
+
+  test("throws for unsupported platform", () => {
+    vi.mocked(platform).mockReturnValue("freebsd");
+    expect(() => getPlatform()).toThrow("Unsupported platform: freebsd");
+  });
+});
+
+describe("getArch", () => {
+  const archs: { val: Arch }[] = [{ val: "x64" }, { val: "arm64" }];
+
+  test.each(archs)("returns $arch", ({ val }) => {
+    vi.mocked(arch).mockReturnValue(val);
+    expect(getArch()).toBe(val);
+  });
+
+  test("throws for unsupported arch", () => {
+    vi.mocked(arch).mockReturnValue("ia32");
+    expect(() => getArch()).toThrow("Unsupported arch: ia32");
+  });
+});
 
 describe("extractVersionFromPackageJson", () => {
   test("returns the version", () => {

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,7 +1,35 @@
 import { getInput } from "ghakit/io";
 import { logError, logInfo } from "ghakit/log";
 import { readFile } from "node:fs/promises";
+import { arch, platform } from "node:os";
 import { basename } from "node:path";
+
+export type Platform = "linux" | "darwin" | "win32";
+
+export function getPlatform(): Platform {
+  const val = platform();
+  switch (val) {
+    case "linux":
+    case "darwin":
+    case "win32":
+      return val;
+    default:
+      throw new Error(`Unsupported platform: ${val}`);
+  }
+}
+
+export type Arch = "x64" | "arm64";
+
+export function getArch(): Arch {
+  const val = arch();
+  switch (val) {
+    case "x64":
+    case "arm64":
+      return val;
+    default:
+      throw new Error(`Unsupported arch: ${val}`);
+  }
+}
 
 export function extractVersionFromPackageJson(packageJson: unknown): string {
   if (typeof packageJson !== "object" || packageJson === null) {

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { Arch, Platform } from "./input.js";
 import {
   getPnpmDownloadUrl,
   resolvePnpmVersion,
@@ -75,8 +76,12 @@ describe("resolvePnpmVersion", { concurrent: true }, () => {
 describe("getPnpmDownloadUrl", { concurrent: true }, () => {
   const combinations = ["10.34.0", "11.5.0"]
     .flatMap((version) =>
-      ["linux", "darwin", "win32"].flatMap((platform) =>
-        ["x64", "arm64"].map((arch) => ({ version, platform, arch })),
+      (["linux", "darwin", "win32"] satisfies Platform[]).flatMap((platform) =>
+        (["x64", "arm64"] satisfies Arch[]).map((arch) => ({
+          version,
+          platform,
+          arch,
+        })),
       ),
     )
     .filter(
@@ -105,26 +110,6 @@ describe("getPnpmDownloadUrl", { concurrent: true }, () => {
     expect(() =>
       getPnpmDownloadUrl({ version: "latest", platform: "linux", arch: "x64" }),
     ).toThrow("Invalid version: latest");
-  });
-
-  test("throws when platform is unsupported", () => {
-    expect(() =>
-      getPnpmDownloadUrl({
-        version: "10.34.0",
-        platform: "freebsd",
-        arch: "x64",
-      }),
-    ).toThrow("Unsupported platform: freebsd");
-  });
-
-  test("throws when arch is unsupported", () => {
-    expect(() =>
-      getPnpmDownloadUrl({
-        version: "10.34.0",
-        platform: "linux",
-        arch: "ia32",
-      }),
-    ).toThrow("Unsupported arch: ia32");
   });
 
   test("throws for x64 macOS on version 11 and above", () => {

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -1,3 +1,5 @@
+import { Arch, Platform } from "./input.js";
+
 export async function resolvePnpmVersionFromResponse(
   version: string,
   res: Response,
@@ -42,48 +44,36 @@ export function getPnpmDownloadUrl({
   arch,
 }: {
   version: string;
-  platform: string;
-  arch: string;
+  platform: Platform;
+  arch: Arch;
 }): URL {
   const match = /^(\d+)/.exec(version);
   if (!match) throw new Error(`Invalid version: ${version}`);
   const major = parseInt(match[1], 10);
 
-  let os: string;
-  switch (platform) {
-    case "linux":
-      os = "linux";
-      break;
-    case "darwin":
-      os = "macos";
-      break;
-    case "win32":
-      os = "win";
-      break;
-    default:
-      throw new Error(`Unsupported platform: ${platform}`);
+  const baseUrl = `https://github.com/pnpm/pnpm/releases/download/v${version}`;
+  if (major >= 11) {
+    if (platform === "darwin" && arch === "x64") {
+      throw new Error(
+        "pnpm does not provide x64 macOS binaries for version 11 and above",
+      );
+    }
+    const ext = platform == "win32" ? ".zip" : ".tar.gz";
+    return new URL(`${baseUrl}/pnpm-${platform}-${arch}${ext}`);
+  } else {
+    let os: string;
+    switch (platform) {
+      case "linux":
+        os = "linux";
+        break;
+      case "darwin":
+        os = "macos";
+        break;
+      case "win32":
+        os = "win";
+        break;
+    }
+    const ext = platform === "win32" ? ".exe" : "";
+    return new URL(`${baseUrl}/pnpm-${os}-${arch}${ext}`);
   }
-
-  switch (arch) {
-    case "x64":
-      if (platform === "darwin" && major >= 11) {
-        throw new Error(
-          "pnpm does not provide x64 macOS binaries for version 11 and above",
-        );
-      }
-      break;
-    case "arm64":
-      break;
-    default:
-      throw new Error(`Unsupported arch: ${arch}`);
-  }
-
-  const file =
-    major >= 11
-      ? `pnpm-${platform}-${arch}${platform == "win32" ? ".zip" : ".tar.gz"}`
-      : `pnpm-${os}-${arch}${platform === "win32" ? ".exe" : ""}`;
-
-  return new URL(
-    `https://github.com/pnpm/pnpm/releases/download/v${version}/${file}`,
-  );
 }


### PR DESCRIPTION
Resolves #267.

Previously, the platform and architecture were only validated inside `getPnpmDownloadUrl` when constructing the download URL — after version resolution and other setup steps had already run. This PR moves that validation to the start of the action via two new functions in `input.ts`:

- `getPlatform()` — reads `node:os` `platform()` and returns a typed `Platform` (`linux | darwin | win32`), throwing immediately on unsupported values.
- `getArch()` — reads `node:os` `arch()` and returns a typed `Arch` (`x64 | arm64`), throwing immediately on unsupported values.

`getPnpmDownloadUrl` now accepts the typed `Platform` and `Arch` values directly, removing the redundant validation it previously performed. The action fails fast before any network calls when run on an unsupported platform or architecture.