### PR TITLE
Return filename and extension separately from getPnpmDownloadUrl

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -2,7 +2,7 @@ import { EOL, platform, arch } from 'os';
 import { spawn } from 'child_process';
 import 'fs';
 import { access, mkdir, rm, readFile, appendFile, chmod } from 'fs/promises';
-import { join, extname, basename, delimiter } from 'path';
+import { join, basename, delimiter } from 'path';
 
 // node_modules/.pnpm/ghakit@1.0.0/node_modules/ghakit/dist/log.js
 function logInfo(message) {
@@ -162,28 +162,25 @@ async function getVersionInput() {
     return "latest";
   }
 }
-async function extractArchive(archiveFile, outputDir) {
-  const ext = extname(archiveFile);
+async function extractArchive(file, ext, outputDir) {
   switch (ext) {
-    case ".gz": {
-      const args = ["-xzvf", archiveFile, "-C", outputDir];
+    case ".tar.gz": {
+      const args = ["-xzvf", file, "-C", outputDir];
       logCommand("tar", ...args);
       await exec("tar", args);
       break;
     }
     case ".zip": {
-      const args = [archiveFile, "-d", outputDir];
+      const args = [file, "-d", outputDir];
       logCommand("unzip", ...args);
       await exec("unzip", args);
       break;
     }
-    default:
-      throw new Error(`Unsupported archive extension: ${ext}`);
   }
 }
-async function makeExecutable(file) {
-  if (extname(file) === ".exe") return;
-  logInfo("Set file permissions");
+async function makeExecutable(file, ext) {
+  if (ext === ".exe") return;
+  logInfo("Make pnpm executable");
   await chmod(file, "755");
 }
 
@@ -219,15 +216,7 @@ function getPnpmDownloadUrl({
   if (!match) throw new Error(`Invalid version: ${version}`);
   const major = parseInt(match[1], 10);
   const baseUrl = `https://github.com/pnpm/pnpm/releases/download/v${version}`;
-  if (major >= 11) {
-    if (platform2 === "darwin" && arch2 === "x64") {
-      throw new Error(
-        "pnpm does not provide x64 macOS binaries for version 11 and above"
-      );
-    }
-    const ext = platform2 == "win32" ? ".zip" : ".tar.gz";
-    return new URL(`${baseUrl}/pnpm-${platform2}-${arch2}${ext}`);
-  } else {
+  if (major < 11) {
     let os;
     switch (platform2) {
       case "linux":
@@ -240,8 +229,22 @@ function getPnpmDownloadUrl({
         os = "win";
         break;
     }
-    const ext = platform2 === "win32" ? ".exe" : "";
-    return new URL(`${baseUrl}/pnpm-${os}-${arch2}${ext}`);
+    return {
+      baseUrl,
+      filename: `pnpm-${os}-${arch2}`,
+      ext: platform2 === "win32" ? ".exe" : ""
+    };
+  } else {
+    if (platform2 === "darwin" && arch2 === "x64") {
+      throw new Error(
+        "pnpm does not provide x64 macOS binaries for version 11 and above"
+      );
+    }
+    return {
+      baseUrl,
+      filename: `pnpm-${platform2}-${arch2}`,
+      ext: platform2 == "win32" ? ".zip" : ".tar.gz"
+    };
   }
 }
 
@@ -258,43 +261,50 @@ async function setupPnpmAction() {
     await access(pnpmHome);
     logInfo(`Use cached pnpm ${version}`);
   } catch {
-    const dlUrl = getPnpmDownloadUrl({ version, platform: platform2, arch: arch2 });
-    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
+    const { baseUrl, filename, ext } = getPnpmDownloadUrl({
+      version,
+      platform: platform2,
+      arch: arch2
+    });
+    const url = `${baseUrl}/${filename}${ext}`;
     logInfo("Create pnpm home");
     await mkdir(pnpmHome, { recursive: true });
-    let dlOut;
-    const dlFileExt = extname(dlFile);
-    switch (dlFileExt) {
-      case ".gz":
-      case ".zip":
-        dlOut = join(pnpmHome, dlFile);
-        break;
-      default:
-        dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
-    }
-    beginLogGroup(`Download pnpm ${version}`);
-    try {
-      const args = ["-fL", "--output", dlOut, dlUrl.href];
-      logCommand("curl", ...args);
-      await exec("curl", args);
-    } finally {
-      endLogGroup();
-    }
-    const dlOutExt = extname(dlOut);
-    switch (dlOutExt) {
-      case ".gz":
-      case ".zip":
-        beginLogGroup("Extract archive");
+    switch (ext) {
+      case "":
+      case ".exe": {
+        const pnpmFile = join(pnpmHome, `pnpm${ext}`);
+        beginLogGroup(`Download pnpm ${version} executable`);
         try {
-          await extractArchive(dlOut, pnpmHome);
+          const args = ["-fL", "--output", pnpmFile, url];
+          logCommand("curl", ...args);
+          await exec("curl", args);
         } finally {
           endLogGroup();
         }
-        logInfo("Remove archive");
-        await rm(dlOut);
+        await makeExecutable(pnpmFile, ext);
         break;
-      default:
-        await makeExecutable(dlOut);
+      }
+      case ".tar.gz":
+      case ".zip": {
+        const archiveFile = join(pnpmHome, filename);
+        beginLogGroup(`Download pnpm ${version} archive`);
+        try {
+          const args = ["-fL", "--output", archiveFile, url];
+          logCommand("curl", ...args);
+          await exec("curl", args);
+        } finally {
+          endLogGroup();
+        }
+        beginLogGroup("Extract pnpm archive");
+        try {
+          await extractArchive(archiveFile, ext, pnpmHome);
+        } finally {
+          endLogGroup();
+        }
+        logInfo("Remove pnpm archive");
+        await rm(archiveFile);
+        break;
+      }
     }
   }
   logInfo("Add pnpm to PATH");

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -86,13 +86,13 @@ describe("setupPnpmAction", () => {
     expect(logs).toStrictEqual([
       "Resolve pnpm version",
       "Create pnpm home",
-      `[begin] Download pnpm ${version}`,
+      `[begin] Download pnpm ${version} archive`,
       "[command]",
       "[end]",
-      "[begin] Extract archive",
+      "[begin] Extract pnpm archive",
       "[command]",
       "[end]",
-      "Remove archive",
+      "Remove pnpm archive",
       "Add pnpm to PATH",
     ]);
 
@@ -117,10 +117,10 @@ describe("setupPnpmAction", () => {
     expect(logs).toStrictEqual([
       "Resolve pnpm version",
       "Create pnpm home",
-      `[begin] Download pnpm ${version}`,
+      `[begin] Download pnpm ${version} executable`,
       "[command]",
       "[end]",
-      "Set file permissions",
+      "Make pnpm executable",
       "Add pnpm to PATH",
     ]);
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -3,7 +3,7 @@ import { addPath, setEnv, setOutput } from "ghakit/io";
 import { beginLogGroup, endLogGroup, logCommand, logInfo } from "ghakit/log";
 import { getRunnerToolCache } from "ghakit/vars";
 import { access, mkdir, rm } from "node:fs/promises";
-import { extname, join } from "node:path";
+import { join } from "node:path";
 import { getArch, getPlatform, getVersionInput } from "./input.js";
 import { extractArchive, makeExecutable } from "./install.js";
 import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
@@ -24,50 +24,58 @@ export async function setupPnpmAction() {
     await access(pnpmHome);
     logInfo(`Use cached pnpm ${version}`);
   } catch {
-    const dlUrl = getPnpmDownloadUrl({ version, platform, arch });
-    const dlFile = dlUrl.pathname.slice(dlUrl.pathname.lastIndexOf("/") + 1);
+    const { baseUrl, filename, ext } = getPnpmDownloadUrl({
+      version,
+      platform,
+      arch,
+    });
+    const url = `${baseUrl}/${filename}${ext}`;
 
     logInfo("Create pnpm home");
     await mkdir(pnpmHome, { recursive: true });
 
-    let dlOut: string;
-    const dlFileExt = extname(dlFile);
-    switch (dlFileExt) {
-      case ".gz":
-      case ".zip":
-        dlOut = join(pnpmHome, dlFile);
-        break;
+    switch (ext) {
+      case "":
+      case ".exe": {
+        const pnpmFile = join(pnpmHome, `pnpm${ext}`);
 
-      default:
-        dlOut = join(pnpmHome, `pnpm${dlFileExt}`);
-    }
-
-    beginLogGroup(`Download pnpm ${version}`);
-    try {
-      const args: string[] = ["-fL", "--output", dlOut, dlUrl.href];
-      logCommand("curl", ...args);
-      await exec("curl", args);
-    } finally {
-      endLogGroup();
-    }
-
-    const dlOutExt = extname(dlOut);
-    switch (dlOutExt) {
-      case ".gz":
-      case ".zip":
-        beginLogGroup("Extract archive");
+        beginLogGroup(`Download pnpm ${version} executable`);
         try {
-          await extractArchive(dlOut, pnpmHome);
+          const args: string[] = ["-fL", "--output", pnpmFile, url];
+          logCommand("curl", ...args);
+          await exec("curl", args);
         } finally {
           endLogGroup();
         }
 
-        logInfo("Remove archive");
-        await rm(dlOut);
+        await makeExecutable(pnpmFile, ext);
         break;
+      }
 
-      default:
-        await makeExecutable(dlOut);
+      case ".tar.gz":
+      case ".zip": {
+        const archiveFile = join(pnpmHome, filename);
+
+        beginLogGroup(`Download pnpm ${version} archive`);
+        try {
+          const args: string[] = ["-fL", "--output", archiveFile, url];
+          logCommand("curl", ...args);
+          await exec("curl", args);
+        } finally {
+          endLogGroup();
+        }
+
+        beginLogGroup("Extract pnpm archive");
+        try {
+          await extractArchive(archiveFile, ext, pnpmHome);
+        } finally {
+          endLogGroup();
+        }
+
+        logInfo("Remove pnpm archive");
+        await rm(archiveFile);
+        break;
+      }
     }
   }
 

--- a/src/install.test.ts
+++ b/src/install.test.ts
@@ -51,7 +51,7 @@ describe("extractArchive", () => {
     await execFileAsync("tar", ["-czf", file, "-C", tmpDir, "tar"]);
     await rm(join(tmpDir, "tar"), { force: true, recursive: true });
 
-    await extractArchive(file, tmpDir);
+    await extractArchive(file, ".tar.gz", tmpDir);
 
     expect(logCommand).toHaveBeenCalledOnce();
 
@@ -67,45 +67,35 @@ describe("extractArchive", () => {
     await execFileAsync("zip", ["-r", file, "zip"], { cwd: tmpDir });
     await rm(join(tmpDir, "zip"), { force: true, recursive: true });
 
-    await extractArchive(file, tmpDir);
+    await extractArchive(file, ".zip", tmpDir);
 
     expect(logCommand).toHaveBeenCalledOnce();
 
     const content = await readFile(join(tmpDir, "zip", "foo", "bar"), "utf-8");
     expect(content).toBe("foo bar");
   });
-
-  test("throws for unsupported archive extension", async () => {
-    await writeFile("archive.7z", "");
-
-    await expect(extractArchive("archive.7z", tmpDir)).rejects.toThrow(
-      "Unsupported archive extension: .7z",
-    );
-
-    expect(logCommand).not.toHaveBeenCalled();
-  });
 });
 
 describe("makeExecutable", () => {
-  test("sets file permissions for files without extension", async () => {
+  test("makes pnpm executable for files without extension", async () => {
     const file = join(tmpDir, "pnpm");
     await writeFile(file, "");
 
-    await makeExecutable(file);
+    await makeExecutable(file, "");
 
     expect(vi.mocked(logInfo).mock.calls).toStrictEqual([
-      ["Set file permissions"],
+      ["Make pnpm executable"],
     ]);
 
     const { mode } = await stat(file);
     expect(mode & 0o111).toBeGreaterThan(0);
   });
 
-  test("skips setting file permissions for .exe files", async () => {
+  test("skips making .exe files executable", async () => {
     const file = join(tmpDir, "pnpm.exe");
     await writeFile(file, "");
 
-    await makeExecutable(file);
+    await makeExecutable(file, ".exe");
 
     expect(logInfo).not.toHaveBeenCalled();
   });

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,32 +1,31 @@
 import { exec } from "ghakit/exec";
 import { logCommand, logInfo } from "ghakit/log";
 import { chmod } from "node:fs/promises";
-import { extname } from "node:path";
 
-export async function extractArchive(archiveFile: string, outputDir: string) {
-  const ext = extname(archiveFile);
+export async function extractArchive(
+  file: string,
+  ext: ".tar.gz" | ".zip",
+  outputDir: string,
+) {
   switch (ext) {
-    case ".gz": {
-      const args: string[] = ["-xzvf", archiveFile, "-C", outputDir];
+    case ".tar.gz": {
+      const args: string[] = ["-xzvf", file, "-C", outputDir];
       logCommand("tar", ...args);
       await exec("tar", args);
       break;
     }
 
     case ".zip": {
-      const args: string[] = [archiveFile, "-d", outputDir];
+      const args: string[] = [file, "-d", outputDir];
       logCommand("unzip", ...args);
       await exec("unzip", args);
       break;
     }
-
-    default:
-      throw new Error(`Unsupported archive extension: ${ext}`);
   }
 }
 
-export async function makeExecutable(file: string) {
-  if (extname(file) === ".exe") return;
-  logInfo("Set file permissions");
+export async function makeExecutable(file: string, ext: "" | ".exe") {
+  if (ext === ".exe") return;
+  logInfo("Make pnpm executable");
   await chmod(file, "755");
 }

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -90,9 +90,14 @@ describe("getPnpmDownloadUrl", { concurrent: true }, () => {
     );
 
   test("returns unique URLs for each combination", () => {
-    const urls = combinations.map(({ version, platform, arch }) =>
-      getPnpmDownloadUrl({ version, platform, arch }),
-    );
+    const urls = combinations.map(({ version, platform, arch }) => {
+      const { baseUrl, filename, ext } = getPnpmDownloadUrl({
+        version,
+        platform,
+        arch,
+      });
+      return `${baseUrl}/${filename}${ext}`;
+    });
     expect(new Set(urls).size).toBe(combinations.length);
   });
 
@@ -100,7 +105,12 @@ describe("getPnpmDownloadUrl", { concurrent: true }, () => {
     "returns accessible URL for $version/$platform/$arch",
     { timeout: 30000 },
     async ({ version, platform, arch }) => {
-      const url = getPnpmDownloadUrl({ version, platform, arch });
+      const { baseUrl, filename, ext } = getPnpmDownloadUrl({
+        version,
+        platform,
+        arch,
+      });
+      const url = `${baseUrl}/${filename}${ext}`;
       const res = await fetch(url, { method: "HEAD" });
       expect(res.ok).toBe(true);
     },

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -46,21 +46,17 @@ export function getPnpmDownloadUrl({
   version: string;
   platform: Platform;
   arch: Arch;
-}): URL {
+}): {
+  baseUrl: string;
+  filename: string;
+  ext: "" | ".exe" | ".tar.gz" | ".zip";
+} {
   const match = /^(\d+)/.exec(version);
   if (!match) throw new Error(`Invalid version: ${version}`);
   const major = parseInt(match[1], 10);
 
   const baseUrl = `https://github.com/pnpm/pnpm/releases/download/v${version}`;
-  if (major >= 11) {
-    if (platform === "darwin" && arch === "x64") {
-      throw new Error(
-        "pnpm does not provide x64 macOS binaries for version 11 and above",
-      );
-    }
-    const ext = platform == "win32" ? ".zip" : ".tar.gz";
-    return new URL(`${baseUrl}/pnpm-${platform}-${arch}${ext}`);
-  } else {
+  if (major < 11) {
     let os: string;
     switch (platform) {
       case "linux":
@@ -73,7 +69,21 @@ export function getPnpmDownloadUrl({
         os = "win";
         break;
     }
-    const ext = platform === "win32" ? ".exe" : "";
-    return new URL(`${baseUrl}/pnpm-${os}-${arch}${ext}`);
+    return {
+      baseUrl,
+      filename: `pnpm-${os}-${arch}`,
+      ext: platform === "win32" ? ".exe" : "",
+    };
+  } else {
+    if (platform === "darwin" && arch === "x64") {
+      throw new Error(
+        "pnpm does not provide x64 macOS binaries for version 11 and above",
+      );
+    }
+    return {
+      baseUrl,
+      filename: `pnpm-${platform}-${arch}`,
+      ext: platform == "win32" ? ".zip" : ".tar.gz",
+    };
   }
 }


### PR DESCRIPTION
Resolves #270.

## Summary

- Changes `getPnpmDownloadUrl` to return `{ baseUrl, filename, ext }` instead of a `URL` object, eliminating the need to parse the URL later to extract filename and extension.
- Updates `action.ts` to destructure the new return value and construct the full URL inline, with separate download log groups for executables and archives.
- Updates `extractArchive` and `makeExecutable` in `install.ts` to accept an explicit `ext` parameter instead of deriving it from the file path.
- Removes the now-unreachable `default` throw in `extractArchive` since the call sites are typed to only pass supported extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)