### PR TITLE
Separate pnpm 11 download URL into its own function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,13 @@ This is a JavaScript GitHub Action that downloads and sets up a standalone pnpm 
 ### Source Files
 
 - **`src/main.ts`** — Entry point that calls the action function and handles error logging and exit codes.
-- **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached, extracts or sets permissions on it, adds it to `PATH`, and sets the `version` output.
+- **`src/action.ts`** — The action implementation; resolves the pnpm version, sets `PNPM_HOME` to `getRunnerToolCache()/pnpm/<version>/`, downloads the binary into the runner tool cache if not already cached (branching on major version: pnpm <11 downloads an executable directly; pnpm >=11 downloads and extracts an archive), adds it to `PATH`, and sets the `version` output.
 - **`src/input.ts`** — Reads the `version` and `version-file` action inputs and resolves them to a version string; parses `package.json` to extract the version from the `packageManager` field when `version-file` is used or when neither input is set and a `package.json` exists in the current directory. Also exports `getPlatform()` and `getArch()`, which validate and return the current `Platform` (`linux | darwin | win32`) and `Arch` (`x64 | arm64`) from `node:os`, throwing on unsupported values.
-- **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry, and builds the download URL for a given version, platform, and arch.
+- **`src/pnpm.ts`** — pnpm-specific utilities: resolves the pnpm version from the NPM registry; `getPnpmMajorVersion(version)` extracts the major version number; `getPnpmDownloadUrl` builds the download URL for pnpm <11 (returns an executable — `""` or `".exe"` extension); `getPnpm11DownloadUrl` builds the download URL for pnpm >=11 (returns an archive — `".tar.gz"` or `".zip"` extension; throws for x64 macOS).
 - **`src/install.ts`** — `extractArchive(archiveFile, outputDir)` extracts `.tar.gz` archives via `tar` and `.zip` archives via `unzip`; `makeExecutable(file)` sets executable permissions on the file, or skips if the file has a `.exe` extension.
 - **`src/action.test.ts`** — Integration tests for the action with a mocked GitHub Actions environment and a real binary download.
 - **`src/input.test.ts`** — Tests for `getPlatform`, `getArch`, `extractVersionFromPackageJson`, and `getVersionInput` in `input.ts`.
-- **`src/pnpm.test.ts`** — Tests for the pure functions in `pnpm.ts`, including live network calls.
+- **`src/pnpm.test.ts`** — Tests for the pure functions in `pnpm.ts`: `getPnpmMajorVersion`, `getPnpmDownloadUrl` (pnpm <11), and `getPnpm11DownloadUrl` (pnpm >=11), including live network calls to verify URL accessibility.
 - **`src/install.test.ts`** — Tests for `extractArchive` and `makeExecutable` in `install.ts`.
 
 ### TypeScript Configuration

--- a/dist/main.js
+++ b/dist/main.js
@@ -207,45 +207,47 @@ async function resolvePnpmVersion(version) {
   const res = await fetch("https://registry.npmjs.org/@pnpm/exe");
   return resolvePnpmVersionFromResponse(version, res);
 }
+function getPnpmMajorVersion(version) {
+  const match = /^(\d+)/.exec(version);
+  if (!match) throw new Error(`Invalid version: ${version}`);
+  return parseInt(match[1], 10);
+}
+function getOsFromPlatform(platform2) {
+  switch (platform2) {
+    case "linux":
+      return "linux";
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "win";
+  }
+}
 function getPnpmDownloadUrl({
   version,
   platform: platform2,
   arch: arch2
 }) {
-  const match = /^(\d+)/.exec(version);
-  if (!match) throw new Error(`Invalid version: ${version}`);
-  const major = parseInt(match[1], 10);
-  const baseUrl = `https://github.com/pnpm/pnpm/releases/download/v${version}`;
-  if (major < 11) {
-    let os;
-    switch (platform2) {
-      case "linux":
-        os = "linux";
-        break;
-      case "darwin":
-        os = "macos";
-        break;
-      case "win32":
-        os = "win";
-        break;
-    }
-    return {
-      baseUrl,
-      filename: `pnpm-${os}-${arch2}`,
-      ext: platform2 === "win32" ? ".exe" : ""
-    };
-  } else {
-    if (platform2 === "darwin" && arch2 === "x64") {
-      throw new Error(
-        "pnpm does not provide x64 macOS binaries for version 11 and above"
-      );
-    }
-    return {
-      baseUrl,
-      filename: `pnpm-${platform2}-${arch2}`,
-      ext: platform2 == "win32" ? ".zip" : ".tar.gz"
-    };
+  return {
+    baseUrl: `https://github.com/pnpm/pnpm/releases/download/v${version}`,
+    filename: `pnpm-${getOsFromPlatform(platform2)}-${arch2}`,
+    ext: platform2 === "win32" ? ".exe" : ""
+  };
+}
+function getPnpm11DownloadUrl({
+  version,
+  platform: platform2,
+  arch: arch2
+}) {
+  if (platform2 === "darwin" && arch2 === "x64") {
+    throw new Error(
+      "pnpm does not provide x64 macOS binaries for version 11 and above"
+    );
   }
+  return {
+    baseUrl: `https://github.com/pnpm/pnpm/releases/download/v${version}`,
+    filename: `pnpm-${platform2}-${arch2}`,
+    ext: platform2 == "win32" ? ".zip" : ".tar.gz"
+  };
 }
 
 // src/action.ts
@@ -255,56 +257,58 @@ async function setupPnpmAction() {
   const versionInput = await getVersionInput();
   logInfo("Resolve pnpm version");
   const version = await resolvePnpmVersion(versionInput);
+  const majorVersion = getPnpmMajorVersion(version);
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
   await setEnv("PNPM_HOME", pnpmHome);
   try {
     await access(pnpmHome);
     logInfo(`Use cached pnpm ${version}`);
   } catch {
-    const { baseUrl, filename, ext } = getPnpmDownloadUrl({
-      version,
-      platform: platform2,
-      arch: arch2
-    });
-    const url = `${baseUrl}/${filename}${ext}`;
-    logInfo("Create pnpm home");
-    await mkdir(pnpmHome, { recursive: true });
-    switch (ext) {
-      case "":
-      case ".exe": {
-        const pnpmFile = join(pnpmHome, `pnpm${ext}`);
-        beginLogGroup(`Download pnpm ${version} executable`);
-        try {
-          const args = ["-fL", "--output", pnpmFile, url];
-          logCommand("curl", ...args);
-          await exec("curl", args);
-        } finally {
-          endLogGroup();
-        }
-        await makeExecutable(pnpmFile, ext);
-        break;
+    if (majorVersion < 11) {
+      const { baseUrl, filename, ext } = getPnpmDownloadUrl({
+        version,
+        platform: platform2,
+        arch: arch2
+      });
+      const url = `${baseUrl}/${filename}${ext}`;
+      logInfo("Create pnpm home");
+      await mkdir(pnpmHome, { recursive: true });
+      beginLogGroup(`Download pnpm ${version} executable`);
+      const execFile = join(pnpmHome, `pnpm${ext}`);
+      try {
+        const args = ["-fL", "--output", execFile, url];
+        logCommand("curl", ...args);
+        await exec("curl", args);
+      } finally {
+        endLogGroup();
       }
-      case ".tar.gz":
-      case ".zip": {
-        const archiveFile = join(pnpmHome, filename);
-        beginLogGroup(`Download pnpm ${version} archive`);
-        try {
-          const args = ["-fL", "--output", archiveFile, url];
-          logCommand("curl", ...args);
-          await exec("curl", args);
-        } finally {
-          endLogGroup();
-        }
-        beginLogGroup("Extract pnpm archive");
-        try {
-          await extractArchive(archiveFile, ext, pnpmHome);
-        } finally {
-          endLogGroup();
-        }
-        logInfo("Remove pnpm archive");
-        await rm(archiveFile);
-        break;
+      await makeExecutable(execFile, ext);
+    } else {
+      const { baseUrl, filename, ext } = getPnpm11DownloadUrl({
+        version,
+        platform: platform2,
+        arch: arch2
+      });
+      const url = `${baseUrl}/${filename}${ext}`;
+      logInfo("Create pnpm home");
+      await mkdir(pnpmHome, { recursive: true });
+      beginLogGroup(`Download pnpm ${version} archive`);
+      const archiveFile = join(pnpmHome, filename);
+      try {
+        const args = ["-fL", "--output", archiveFile, url];
+        logCommand("curl", ...args);
+        await exec("curl", args);
+      } finally {
+        endLogGroup();
       }
+      beginLogGroup("Extract pnpm archive");
+      try {
+        await extractArchive(archiveFile, ext, pnpmHome);
+      } finally {
+        endLogGroup();
+      }
+      logInfo("Remove pnpm archive");
+      await rm(archiveFile);
     }
   }
   logInfo("Add pnpm to PATH");

--- a/src/action.ts
+++ b/src/action.ts
@@ -6,7 +6,12 @@ import { access, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { getArch, getPlatform, getVersionInput } from "./input.js";
 import { extractArchive, makeExecutable } from "./install.js";
-import { getPnpmDownloadUrl, resolvePnpmVersion } from "./pnpm.js";
+import {
+  getPnpm11DownloadUrl,
+  getPnpmDownloadUrl,
+  getPnpmMajorVersion,
+  resolvePnpmVersion,
+} from "./pnpm.js";
 
 export async function setupPnpmAction() {
   const platform = getPlatform();
@@ -16,6 +21,7 @@ export async function setupPnpmAction() {
 
   logInfo("Resolve pnpm version");
   const version = await resolvePnpmVersion(versionInput);
+  const majorVersion = getPnpmMajorVersion(version);
 
   const pnpmHome = join(getRunnerToolCache(), "pnpm", version);
   await setEnv("PNPM_HOME", pnpmHome);
@@ -24,58 +30,58 @@ export async function setupPnpmAction() {
     await access(pnpmHome);
     logInfo(`Use cached pnpm ${version}`);
   } catch {
-    const { baseUrl, filename, ext } = getPnpmDownloadUrl({
-      version,
-      platform,
-      arch,
-    });
-    const url = `${baseUrl}/${filename}${ext}`;
+    if (majorVersion < 11) {
+      const { baseUrl, filename, ext } = getPnpmDownloadUrl({
+        version,
+        platform,
+        arch,
+      });
+      const url = `${baseUrl}/${filename}${ext}`;
 
-    logInfo("Create pnpm home");
-    await mkdir(pnpmHome, { recursive: true });
+      logInfo("Create pnpm home");
+      await mkdir(pnpmHome, { recursive: true });
 
-    switch (ext) {
-      case "":
-      case ".exe": {
-        const pnpmFile = join(pnpmHome, `pnpm${ext}`);
-
-        beginLogGroup(`Download pnpm ${version} executable`);
-        try {
-          const args: string[] = ["-fL", "--output", pnpmFile, url];
-          logCommand("curl", ...args);
-          await exec("curl", args);
-        } finally {
-          endLogGroup();
-        }
-
-        await makeExecutable(pnpmFile, ext);
-        break;
+      beginLogGroup(`Download pnpm ${version} executable`);
+      const execFile = join(pnpmHome, `pnpm${ext}`);
+      try {
+        const args: string[] = ["-fL", "--output", execFile, url];
+        logCommand("curl", ...args);
+        await exec("curl", args);
+      } finally {
+        endLogGroup();
       }
 
-      case ".tar.gz":
-      case ".zip": {
-        const archiveFile = join(pnpmHome, filename);
+      await makeExecutable(execFile, ext);
+    } else {
+      const { baseUrl, filename, ext } = getPnpm11DownloadUrl({
+        version,
+        platform,
+        arch,
+      });
+      const url = `${baseUrl}/${filename}${ext}`;
 
-        beginLogGroup(`Download pnpm ${version} archive`);
-        try {
-          const args: string[] = ["-fL", "--output", archiveFile, url];
-          logCommand("curl", ...args);
-          await exec("curl", args);
-        } finally {
-          endLogGroup();
-        }
+      logInfo("Create pnpm home");
+      await mkdir(pnpmHome, { recursive: true });
 
-        beginLogGroup("Extract pnpm archive");
-        try {
-          await extractArchive(archiveFile, ext, pnpmHome);
-        } finally {
-          endLogGroup();
-        }
-
-        logInfo("Remove pnpm archive");
-        await rm(archiveFile);
-        break;
+      beginLogGroup(`Download pnpm ${version} archive`);
+      const archiveFile = join(pnpmHome, filename);
+      try {
+        const args: string[] = ["-fL", "--output", archiveFile, url];
+        logCommand("curl", ...args);
+        await exec("curl", args);
+      } finally {
+        endLogGroup();
       }
+
+      beginLogGroup("Extract pnpm archive");
+      try {
+        await extractArchive(archiveFile, ext, pnpmHome);
+      } finally {
+        endLogGroup();
+      }
+
+      logInfo("Remove pnpm archive");
+      await rm(archiveFile);
     }
   }
 

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { Arch, Platform } from "./input.js";
 import {
+  getPnpm11DownloadUrl,
   getPnpmDownloadUrl,
+  getPnpmMajorVersion,
   resolvePnpmVersion,
   resolvePnpmVersionFromResponse,
 } from "./pnpm.js";
@@ -73,21 +75,28 @@ describe("resolvePnpmVersion", { concurrent: true }, () => {
   });
 });
 
-describe("getPnpmDownloadUrl", { concurrent: true }, () => {
-  const combinations = ["10.34.0", "11.5.0"]
-    .flatMap((version) =>
-      (["linux", "darwin", "win32"] satisfies Platform[]).flatMap((platform) =>
-        (["x64", "arm64"] satisfies Arch[]).map((arch) => ({
-          version,
-          platform,
-          arch,
-        })),
-      ),
-    )
-    .filter(
-      ({ version, platform, arch }) =>
-        version !== "11.5.0" || platform !== "darwin" || arch !== "x64",
+describe("getPnpmMajorVersion", () => {
+  test("returns major version", () => {
+    expect(getPnpmMajorVersion("10.34.0")).toBe(10);
+  });
+
+  test("throws when version is invalid", () => {
+    expect(() => getPnpmMajorVersion("latest")).toThrow(
+      "Invalid version: latest",
     );
+  });
+});
+
+describe("getPnpmDownloadUrl", { concurrent: true }, () => {
+  const combinations = ["9.15.0", "10.34.0"].flatMap((version) =>
+    (["linux", "darwin", "win32"] satisfies Platform[]).flatMap((platform) =>
+      (["x64", "arm64"] satisfies Arch[]).map((arch) => ({
+        version,
+        platform,
+        arch,
+      })),
+    ),
+  );
 
   test("returns unique URLs for each combination", () => {
     const urls = combinations.map(({ version, platform, arch }) => {
@@ -115,16 +124,51 @@ describe("getPnpmDownloadUrl", { concurrent: true }, () => {
       expect(res.ok).toBe(true);
     },
   );
+});
 
-  test("throws when version is invalid", () => {
-    expect(() =>
-      getPnpmDownloadUrl({ version: "latest", platform: "linux", arch: "x64" }),
-    ).toThrow("Invalid version: latest");
+describe("getPnpm11DownloadUrl", { concurrent: true }, () => {
+  const combinations = ["11.4.0", "11.5.0"]
+    .flatMap((version) =>
+      (["linux", "darwin", "win32"] satisfies Platform[]).flatMap((platform) =>
+        (["x64", "arm64"] satisfies Arch[]).map((arch) => ({
+          version,
+          platform,
+          arch,
+        })),
+      ),
+    )
+    .filter(({ platform, arch }) => platform !== "darwin" || arch !== "x64");
+
+  test("returns unique URLs for each combination", () => {
+    const urls = combinations.map(({ version, platform, arch }) => {
+      const { baseUrl, filename, ext } = getPnpm11DownloadUrl({
+        version,
+        platform,
+        arch,
+      });
+      return `${baseUrl}/${filename}${ext}`;
+    });
+    expect(new Set(urls).size).toBe(combinations.length);
   });
+
+  test.each(combinations)(
+    "returns accessible URL for $version/$platform/$arch",
+    { timeout: 30000 },
+    async ({ version, platform, arch }) => {
+      const { baseUrl, filename, ext } = getPnpm11DownloadUrl({
+        version,
+        platform,
+        arch,
+      });
+      const url = `${baseUrl}/${filename}${ext}`;
+      const res = await fetch(url, { method: "HEAD" });
+      expect(res.ok).toBe(true);
+    },
+  );
 
   test("throws for x64 macOS on version 11 and above", () => {
     expect(() =>
-      getPnpmDownloadUrl({
+      getPnpm11DownloadUrl({
         version: "11.5.0",
         platform: "darwin",
         arch: "x64",

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -38,6 +38,23 @@ export async function resolvePnpmVersion(version: string): Promise<string> {
   return resolvePnpmVersionFromResponse(version, res);
 }
 
+export function getPnpmMajorVersion(version: string): number {
+  const match = /^(\d+)/.exec(version);
+  if (!match) throw new Error(`Invalid version: ${version}`);
+  return parseInt(match[1], 10);
+}
+
+function getOsFromPlatform(platform: Platform): string {
+  switch (platform) {
+    case "linux":
+      return "linux";
+    case "darwin":
+      return "macos";
+    case "win32":
+      return "win";
+  }
+}
+
 export function getPnpmDownloadUrl({
   version,
   platform,
@@ -49,41 +66,36 @@ export function getPnpmDownloadUrl({
 }): {
   baseUrl: string;
   filename: string;
-  ext: "" | ".exe" | ".tar.gz" | ".zip";
+  ext: "" | ".exe";
 } {
-  const match = /^(\d+)/.exec(version);
-  if (!match) throw new Error(`Invalid version: ${version}`);
-  const major = parseInt(match[1], 10);
+  return {
+    baseUrl: `https://github.com/pnpm/pnpm/releases/download/v${version}`,
+    filename: `pnpm-${getOsFromPlatform(platform)}-${arch}`,
+    ext: platform === "win32" ? ".exe" : "",
+  };
+}
 
-  const baseUrl = `https://github.com/pnpm/pnpm/releases/download/v${version}`;
-  if (major < 11) {
-    let os: string;
-    switch (platform) {
-      case "linux":
-        os = "linux";
-        break;
-      case "darwin":
-        os = "macos";
-        break;
-      case "win32":
-        os = "win";
-        break;
-    }
-    return {
-      baseUrl,
-      filename: `pnpm-${os}-${arch}`,
-      ext: platform === "win32" ? ".exe" : "",
-    };
-  } else {
-    if (platform === "darwin" && arch === "x64") {
-      throw new Error(
-        "pnpm does not provide x64 macOS binaries for version 11 and above",
-      );
-    }
-    return {
-      baseUrl,
-      filename: `pnpm-${platform}-${arch}`,
-      ext: platform == "win32" ? ".zip" : ".tar.gz",
-    };
+export function getPnpm11DownloadUrl({
+  version,
+  platform,
+  arch,
+}: {
+  version: string;
+  platform: Platform;
+  arch: Arch;
+}): {
+  baseUrl: string;
+  filename: string;
+  ext: ".tar.gz" | ".zip";
+} {
+  if (platform === "darwin" && arch === "x64") {
+    throw new Error(
+      "pnpm does not provide x64 macOS binaries for version 11 and above",
+    );
   }
+  return {
+    baseUrl: `https://github.com/pnpm/pnpm/releases/download/v${version}`,
+    filename: `pnpm-${platform}-${arch}`,
+    ext: platform == "win32" ? ".zip" : ".tar.gz",
+  };
 }


### PR DESCRIPTION
Resolves #269.

## Summary

- Adds `getPnpmMajorVersion(version)` to extract the major version number from a resolved pnpm version string.
- Splits the old `getPnpmDownloadUrl` into two dedicated functions: `getPnpmDownloadUrl` for pnpm <11 (returns an executable with `""` or `".exe"` extension) and `getPnpm11DownloadUrl` for pnpm >=11 (returns an archive with `".tar.gz"` or `".zip"` extension).
- Updates `action.ts` to resolve the major version upfront and branch between the two download paths explicitly, making the installation flow easier to follow.
- Updates tests to cover `getPnpmMajorVersion` and both download URL functions separately, including live network checks for each.