### PR TITLE
Bump pnpm to version 11.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
       "onFail": "download"
     }
   },
-  "packageManager": "pnpm@11.5.1"
+  "packageManager": "pnpm@11.5.2"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [11.5.2](https://github.com/pnpm/pnpm/releases/tag/v11.5.2).