### PR TITLE
Fix typos and loose equality in pnpm utilities

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -183,7 +183,7 @@ async function makeExecutable(file, ext) {
   logInfo("Make pnpm executable");
   await chmod(file, "755");
 }
-async function fecthNpmPackageRegistry(pkg) {
+async function fetchNpmPackageRegistry(pkg) {
   const res = await fetch(`https://registry.npmjs.org/${pkg}`);
   if (!res.ok) {
     throw new Error(
@@ -274,7 +274,7 @@ function getPnpm11DownloadUrl({
   return {
     baseUrl: `https://github.com/pnpm/pnpm/releases/download/v${version}`,
     filename: `pnpm-${platform2}-${arch2}`,
-    ext: platform2 == "win32" ? ".zip" : ".tar.gz"
+    ext: platform2 === "win32" ? ".zip" : ".tar.gz"
   };
 }
 
@@ -285,11 +285,11 @@ async function setupPnpmAction() {
   let version = await getVersionInput();
   if (/^\d+\.\d+\.\d+/.test(version)) {
     logInfo(`Verify pnpm version ${version}`);
-    const registry = await fecthNpmPackageRegistry("@pnpm/exe");
+    const registry = await fetchNpmPackageRegistry("@pnpm/exe");
     verifyPnpmVersion(version, registry);
   } else {
     logInfo(`Resolve pnpm version from ${version}`);
-    const registry = await fecthNpmPackageRegistry("@pnpm/exe");
+    const registry = await fetchNpmPackageRegistry("@pnpm/exe");
     version = resolvePnpmVersion(version, registry);
     logInfo(`Use pnpm version ${version}`);
   }

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -18,7 +18,7 @@ import {
 import { setupPnpmAction } from "./action.js";
 import { getVersionInput } from "./input.js";
 import {
-  fecthNpmPackageRegistry,
+  fetchNpmPackageRegistry,
   getPnpmHome,
   resolvePnpmVersion,
 } from "./pnpm.js";
@@ -76,7 +76,7 @@ describe("setupPnpmAction", () => {
   };
 
   beforeAll(async () => {
-    const registry = await fecthNpmPackageRegistry("@pnpm/exe");
+    const registry = await fetchNpmPackageRegistry("@pnpm/exe");
     latestVersion = resolvePnpmVersion("latest", registry);
   });
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { getArch, getPlatform, getVersionInput } from "./input.js";
 import { extractArchive, makeExecutable } from "./install.js";
 import {
-  fecthNpmPackageRegistry,
+  fetchNpmPackageRegistry,
   getPnpm11DownloadUrl,
   getPnpmDownloadUrl,
   getPnpmHome,
@@ -22,11 +22,11 @@ export async function setupPnpmAction() {
   let version = await getVersionInput();
   if (/^\d+\.\d+\.\d+/.test(version)) {
     logInfo(`Verify pnpm version ${version}`);
-    const registry = await fecthNpmPackageRegistry("@pnpm/exe");
+    const registry = await fetchNpmPackageRegistry("@pnpm/exe");
     verifyPnpmVersion(version, registry);
   } else {
     logInfo(`Resolve pnpm version from ${version}`);
-    const registry = await fecthNpmPackageRegistry("@pnpm/exe");
+    const registry = await fetchNpmPackageRegistry("@pnpm/exe");
     version = resolvePnpmVersion(version, registry);
     logInfo(`Use pnpm version ${version}`);
   }

--- a/src/pnpm.test.ts
+++ b/src/pnpm.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { Arch, Platform } from "./input.js";
 import {
-  fecthNpmPackageRegistry,
+  fetchNpmPackageRegistry,
   getPnpm11DownloadUrl,
   getPnpmDownloadUrl,
   getPnpmHome,
@@ -14,14 +14,14 @@ import {
 
 vi.mock(import("ghakit/vars"));
 
-describe("fecthNpmPackageRegistry", { concurrent: true }, () => {
+describe("fetchNpmPackageRegistry", { concurrent: true }, () => {
   test("returns package registry", async () => {
-    const registry = await fecthNpmPackageRegistry("@pnpm/exe");
+    const registry = await fetchNpmPackageRegistry("@pnpm/exe");
     expect(registry).not.toBeUndefined();
   });
 
   test("throws for not found package", async () => {
-    await expect(fecthNpmPackageRegistry("@pnpm/exeee")).rejects.toThrow(
+    await expect(fetchNpmPackageRegistry("@pnpm/exeee")).rejects.toThrow(
       "Failed to fetch @pnpm/exeee from npm registry: Not Found",
     );
   });
@@ -66,7 +66,7 @@ describe("resolvePnpmVersion", { concurrent: true }, () => {
 });
 
 describe("verifyPnpmVersion", { concurrent: true }, () => {
-  test("verify a pnpm verion", () => {
+  test("verify a pnpm version", () => {
     const registry = { versions: { "10.34.0": {} } };
     expect(() => {
       verifyPnpmVersion("10.34.0", registry);

--- a/src/pnpm.ts
+++ b/src/pnpm.ts
@@ -2,7 +2,7 @@ import { getRunnerToolCache } from "ghakit/vars";
 import { join } from "node:path";
 import { Arch, Platform } from "./input.js";
 
-export async function fecthNpmPackageRegistry(pkg: string): Promise<unknown> {
+export async function fetchNpmPackageRegistry(pkg: string): Promise<unknown> {
   const res = await fetch(`https://registry.npmjs.org/${pkg}`);
   if (!res.ok) {
     throw new Error(
@@ -128,6 +128,6 @@ export function getPnpm11DownloadUrl({
   return {
     baseUrl: `https://github.com/pnpm/pnpm/releases/download/v${version}`,
     filename: `pnpm-${platform}-${arch}`,
-    ext: platform == "win32" ? ".zip" : ".tar.gz",
+    ext: platform === "win32" ? ".zip" : ".tar.gz",
   };
 }


### PR DESCRIPTION
## Summary

- Rename `fecthNpmPackageRegistry` to `fetchNpmPackageRegistry` across all source and test files
- Fix loose equality operator (`==` → `===`) in `getPnpm11DownloadUrl` in `src/pnpm.ts`
- Fix test description typo (`verion` → `version`) in `src/pnpm.test.ts`