### PR TITLE
Remove redundant default: "" from action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,8 @@ branding:
 inputs:
   version:
     description: The version or tag of pnpm to install.
-    default: ""
   version-file:
     description: A file specifying the version of pnpm to install. Supports package.json with a packageManager field.
-    default: ""
 outputs:
   version:
     description: The version of pnpm that was installed.


### PR DESCRIPTION
Closes #281

`getInput()` from `ghakit` already returns an empty string when an input is not supplied by the caller, so declaring `default: ""` on the `version` and `version-file` inputs produces no change in runtime behavior. This removes those redundant declarations to keep the action definition minimal.